### PR TITLE
Added mixed and velocity-dependent mixed BCs, CORs, and tests. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,10 @@ These parameters control the numerical discretization, algorithm selection, and 
 | `external_magnetic_field_amplitude`  | Amplitude of external B-field (cosine). |
 | `external_magnetic_field_wavenumber` | Wavenumber of external B-field. |
 | **Boundary Conditions** | | |
-| `particle_BC_left,right` | Left,right particle boundary conditon (0: periodic, 1: reflective, 2: absorbing). |
+| `particle_BC_left,right` | Left/right particle boundary condition: **0** periodic, **1** reflective, **2** absorbing, **3** mixed (static weight), **4** mixed (velocity-dependent weight). |
+| `field_BC_left,right` | Left/right field boundary condition: **0** periodic, **1** Dirichlet (E=0 at wall). |
+| `mixed_BC_weight` | Fraction of each macroparticle reflected at a BC=3 wall (0 = fully absorbing, 1 = fully reflective). |
+| `COR_left,right` | Coefficient of restitution at the left/right wall for reflective BCs. (1.0 = elastic, 0.0 = fully inelastic.) |
 | **Numerics** | | |
 | `filter_passes` | Number of passes of the digital filter for charge/current density. |
 | `filter_alpha`  | Smoothing strength (0.0 to 1.0). |

--- a/examples/bc_parameter_comparison.py
+++ b/examples/bc_parameter_comparison.py
@@ -1,13 +1,11 @@
 ## bc_parameter_comparison.py
 # Compares BC=3 (mixed, static weight) at three different weight values and BC=4
-# (velocity-dependent weight). Runs all simulations and show kinetic energy
+# (velocity-dependent weight). Runs all simulations and shows kinetic energy
 # comparison.
-from jaxincell import plot, simulation, diagnostics
+from jaxincell import simulation, diagnostics
 from jax import block_until_ready
 import matplotlib.pyplot as plt
 import numpy as np
-
-####################################################################################################
 
 input_parameters = {
     "length"                                        : 1,     # dimensions of the simulation box in (x, y, z)
@@ -34,7 +32,6 @@ configs = [
     {"label": "BC=4 (vel-dep.)",   "particle_BC_left": 4, "particle_BC_right": 4},
 ]
 
-####################################################################################################
 
 outputs = []
 for cfg in configs:
@@ -46,7 +43,6 @@ for cfg in configs:
     output["_label"] = label
     outputs.append(output)
 
-####################################################################################################
 
 # Kinetic energy comparison across all configurations
 plt.figure(figsize=(8, 5))
@@ -61,9 +57,3 @@ plt.legend()
 plt.tight_layout()
 plt.show()
 
-####################################################################################################
-
-# Full animated plot for each configuration (close each window to advance)
-for output in outputs:
-    print(f"\nPlotting {output['_label']} (close window to continue)...")
-    plot(output, animation_interval=20)

--- a/examples/bc_parameter_comparison.py
+++ b/examples/bc_parameter_comparison.py
@@ -1,0 +1,70 @@
+## bc_parameter_comparison.py
+# Compares BC=3 (mixed, static weight) at three different weight values and BC=4
+# (velocity-dependent weight). Runs all simulations and show kinetic energy
+# comparison.
+from jaxincell import plot, simulation, diagnostics
+from jax import block_until_ready
+import matplotlib.pyplot as plt
+import numpy as np
+
+####################################################################################################
+
+input_parameters = {
+    "length"                                        : 1,     # dimensions of the simulation box in (x, y, z)
+    "vth_electrons_over_c_x"                        : 0.1,   # thermal velocity of electrons over speed of light
+    "ion_temperature_over_electron_temperature_x"   : 1e-9,  # cold ions (fixed neutralizing background)
+    "ion_mass_over_proton_mass"                     : 1e9,   # heavy ions (essentially stationary)
+    "timestep_over_spatialstep_times_c"             : 0.5,   # dt * speed_of_light / dx
+    "field_BC_left"                                 : 1,     # Dirichlet (E=0) at left wall
+    "field_BC_right"                                : 1,     # Dirichlet (E=0) at right wall
+    "print_info"                                    : True,  # print information about the simulation
+}
+
+solver_parameters = {
+    "field_solver"           : 0,    # Algorithm to solve E and B fields - 0: Curl_EB, 1: Gauss_1D_FFT, 2: Gauss_1D_Cartesian, 3: Poisson_1D_FFT
+    "number_grid_points"     : 32,   # Number of grid points
+    "number_pseudoelectrons" : 5000, # Number of pseudoelectrons
+    "total_steps"            : 500,  # Total number of time steps
+}
+
+configs = [
+    {"label": "BC=3, weight=0.25", "particle_BC_left": 3, "particle_BC_right": 3, "mixed_BC_weight": 0.25},
+    {"label": "BC=3, weight=0.50", "particle_BC_left": 3, "particle_BC_right": 3, "mixed_BC_weight": 0.50},
+    {"label": "BC=3, weight=0.75", "particle_BC_left": 3, "particle_BC_right": 3, "mixed_BC_weight": 0.75},
+    {"label": "BC=4 (vel-dep.)",   "particle_BC_left": 4, "particle_BC_right": 4},
+]
+
+####################################################################################################
+
+outputs = []
+for cfg in configs:
+    label = cfg.pop("label")
+    print(f"\nRunning {label}...")
+    params = {**input_parameters, **cfg}
+    output = block_until_ready(simulation(params, **solver_parameters))
+    diagnostics(output)
+    output["_label"] = label
+    outputs.append(output)
+
+####################################################################################################
+
+# Kinetic energy comparison across all configurations
+plt.figure(figsize=(8, 5))
+for output in outputs:
+    t  = np.asarray(output["time_array"]) * float(output["plasma_frequency"])
+    ke = np.asarray(output["kinetic_energy_electrons"])
+    plt.plot(t, ke / ke[0], label=output["_label"])
+plt.xlabel(r"$t\,\omega_{pe}$", fontsize=13)
+plt.ylabel(r"$KE_e\,/\,KE_e(0)$", fontsize=13)
+plt.title("Electron kinetic energy over time", fontsize=13)
+plt.legend()
+plt.tight_layout()
+plt.savefig("bc_comparison_KE.pdf", dpi=300)
+plt.show()
+
+####################################################################################################
+
+# Full animated plot for each configuration (close each window to advance)
+for output in outputs:
+    print(f"\nPlotting {output['_label']} (close window to continue)...")
+    plot(output, animation_interval=20)

--- a/examples/bc_parameter_comparison.py
+++ b/examples/bc_parameter_comparison.py
@@ -59,7 +59,6 @@ plt.ylabel(r"$KE_e\,/\,KE_e(0)$", fontsize=13)
 plt.title("Electron kinetic energy over time", fontsize=13)
 plt.legend()
 plt.tight_layout()
-plt.savefig("bc_comparison_KE.pdf", dpi=300)
 plt.show()
 
 ####################################################################################################

--- a/examples/mixed_bc.py
+++ b/examples/mixed_bc.py
@@ -1,0 +1,37 @@
+## mixed_bc.py
+# Example of mixed boundary conditions (BC=3): at each wall collision, a fraction
+# of the macroparticle reflects and the rest is absorbed, controlled by mixed_BC_weight.
+# mixed_BC_weight=1.0 is equivalent to fully reflective (BC=1);
+# mixed_BC_weight=0.0 is equivalent to fully absorbing (BC=2).
+from jaxincell import plot
+from jaxincell import simulation, diagnostics
+import jax.numpy as jnp
+from jax import block_until_ready
+
+input_parameters = {
+    "length"                                        : 1,     # dimensions of the simulation box in (x, y, z)
+    "vth_electrons_over_c_x"                        : 0.1,   # thermal velocity of electrons over speed of light
+    "ion_temperature_over_electron_temperature_x"   : 1e-9,  # cold ions (fixed neutralizing background)
+    "ion_mass_over_proton_mass"                     : 1e9,   # heavy ions (essentially stationary)
+    "timestep_over_spatialstep_times_c"             : 0.5,   # dt * speed_of_light / dx
+    "particle_BC_left"                              : 3,     # mixed BC at left wall
+    "particle_BC_right"                             : 3,     # mixed BC at right wall
+    "field_BC_left"                                 : 1,     # Dirichlet (E=0) at left wall
+    "field_BC_right"                                : 1,     # Dirichlet (E=0) at right wall
+    "mixed_BC_weight"                               : 0.5,   # fraction of each macroparticle reflected; remainder absorbed
+    "print_info"                                    : True,  # print information about the simulation
+}
+
+solver_parameters = {
+    "field_solver"           : 0,    # Algorithm to solve E and B fields - 0: Curl_EB, 1: Gauss_1D_FFT, 2: Gauss_1D_Cartesian, 3: Poisson_1D_FFT
+    "number_grid_points"     : 32,   # Number of grid points
+    "number_pseudoelectrons" : 5000, # Number of pseudoelectrons
+    "total_steps"            : 500,  # Total number of time steps
+}
+
+output = block_until_ready(simulation(input_parameters, **solver_parameters))
+
+# Post-process: segregate ions/electrons, compute energies, compute FFT
+diagnostics(output)
+
+plot(output)

--- a/jaxincell/_algorithms.py
+++ b/jaxincell/_algorithms.py
@@ -17,7 +17,7 @@ __all__ = ['Boris_step', 'CN_step']
 def Boris_step(carry, step_index, parameters, dx, dt, grid, box_size,
                       particle_BC_left, particle_BC_right,
                       field_BC_left, field_BC_right, mixed_BC_weight,
-                      field_solver):
+                      field_solver, COR_left, COR_right):
 
     (E_field, B_field, positions_minus1_2, positions,
     positions_plus1_2, velocities, qs, ms, q_ms) = carry
@@ -55,7 +55,7 @@ def Boris_step(carry, step_index, parameters, dx, dt, grid, box_size,
     # Apply boundary conditions
     positions_plus3_2, velocities_plus1, qs, ms, q_ms = set_BC_particles(
         positions_plus3_2, velocities_plus1, qs, ms, q_ms, dx, grid,
-        *box_size, particle_BC_left, particle_BC_right, mixed_BC_weight)
+        *box_size, particle_BC_left, particle_BC_right, mixed_BC_weight, COR_left, COR_right)
     
     positions_plus1 = set_BC_positions(positions_plus3_2 - (dt / 2) * velocities_plus1,
                                     qs, dx, grid, *box_size, particle_BC_left, particle_BC_right)
@@ -100,7 +100,7 @@ def Boris_step(carry, step_index, parameters, dx, dt, grid, box_size,
 @partial(jit, static_argnames=('num_substeps', 'particle_BC_left', 'particle_BC_right', 'field_BC_left', 'field_BC_right'))
 def CN_step(carry, step_index, parameters, dx, dt, grid, box_size,
                                   particle_BC_left, particle_BC_right,
-                                  field_BC_left, field_BC_right, mixed_BC_weight, num_substeps):
+                                  field_BC_left, field_BC_right, mixed_BC_weight, num_substeps, COR_left, COR_right):
     (E_field, B_field, positions,
     velocities, qs, ms, q_ms) = carry
     
@@ -162,7 +162,7 @@ def CN_step(carry, step_index, parameters, dx, dt, grid, box_size,
             # BCs
             pos_new, vel_mid, qs_new, ms_new, q_ms_new = set_BC_particles(
                 pos_new, vel_mid, qs_sub, ms_sub, q_ms_sub,
-                dx, grid, *box_size, particle_BC_left, particle_BC_right, mixed_BC_weight
+                dx, grid, *box_size, particle_BC_left, particle_BC_right, mixed_BC_weight, COR_left, COR_right
             )
             pos_stag_new = set_BC_positions(
                 pos_new - 0.5*dtau*vel_mid,

--- a/jaxincell/_algorithms.py
+++ b/jaxincell/_algorithms.py
@@ -224,7 +224,7 @@ def CN_step(carry, step_index, parameters, dx, dt, grid, box_size,
 
     final_carry, J, _, _ = lax.while_loop(cond_fn, body_fn, state0)
     
-    (E_prev, E_final, B_final, _, positions_new, _, velocities_new, _, _, _, _) = final_carry
+    (E_prev, E_final, B_final, _, positions_new, _, velocities_new, charges_new, masses_new, charge_ratios_new, _) = final_carry
 
     # Store Data
     E_field = E_final
@@ -232,10 +232,10 @@ def CN_step(carry, step_index, parameters, dx, dt, grid, box_size,
     positions_plus1 = positions_new
     velocities_plus1 = velocities_new
     
-    charge_density = calculate_charge_density(positions_new, qs, dx, grid, particle_BC_left, particle_BC_right,
+    charge_density = calculate_charge_density(positions_new, charges_new, dx, grid, particle_BC_left, particle_BC_right,
                                               filter_passes=0, filter_alpha=0.5, filter_strides=(1, 2, 4),
                                               field_BC_left=field_BC_left, field_BC_right=field_BC_right)
-    carry = (E_field, B_field, positions_plus1, velocities_plus1, qs, ms, q_ms)
-    step_data = (positions_plus1, velocities_plus1, ms, E_field, B_field, J, charge_density)
+    carry = (E_field, B_field, positions_plus1, velocities_plus1, charges_new, masses_new, charge_ratios_new)
+    step_data = (positions_plus1, velocities_plus1, masses_new, E_field, B_field, J, charge_density)
 
     return carry, step_data

--- a/jaxincell/_boundary_conditions.py
+++ b/jaxincell/_boundary_conditions.py
@@ -4,7 +4,7 @@ from ._constants import speed_of_light
 
 __all__ = ['set_BC_single_particle', 'set_BC_particles', 'set_BC_single_particle_positions', 'set_BC_positions']
 
-def set_BC_single_particle(x_n, v_n, q, q_m, m, dx, grid, box_size_x, box_size_y, box_size_z, BC_left, BC_right, mixed_BC_weight, COR_left, COR_right, max_vx=1.0):
+def set_BC_single_particle(x_n, v_n, q, q_m, m, dx, grid, box_size_x, box_size_y, box_size_z, BC_left, BC_right, mixed_BC_weight=1.0, COR_left=1.0, COR_right=1.0, max_vx=1.0):
     """
     Applies boundary conditions (BCs) to a single particle's position and velocity.
 
@@ -55,8 +55,8 @@ def set_BC_single_particle(x_n, v_n, q, q_m, m, dx, grid, box_size_x, box_size_y
         default=x_n[0]
     )
 
-    # Compute vel_dep_weight from incoming velocity before the flip
-    vel_dep_weight = jnp.clip(1.0 - jnp.abs(v_n[0]) / max_vx, 0.0, 1.0)
+    # Compute vel_dep_weight from incoming velocity before the flip, set 
+    vel_dep_weight = jnp.clip(1.0 - jnp.abs(v_n[0]) / (max_vx + 1e-6), 0.0, 1.0)
 
     # Update velocities for reflective or absorbing boundaries
     v_n = jnp.select(
@@ -85,7 +85,7 @@ def set_BC_single_particle(x_n, v_n, q, q_m, m, dx, grid, box_size_x, box_size_y
     return jnp.array([x_n0, x_n1, x_n2]), v_n, q, q_m, m
 
 @jit
-def set_BC_particles(xs_n, vs_n, qs, ms, q_ms, dx, grid, box_size_x, box_size_y, box_size_z, BC_left, BC_right, mixed_BC_weight, COR_left, COR_right):
+def set_BC_particles(xs_n, vs_n, qs, ms, q_ms, dx, grid, box_size_x, box_size_y, box_size_z, BC_left, BC_right, mixed_BC_weight=1.0, COR_left=1.0, COR_right=1.0):
     """
     Applies boundary conditions to all particles in parallel.
 
@@ -100,7 +100,10 @@ def set_BC_particles(xs_n, vs_n, qs, ms, q_ms, dx, grid, box_size_x, box_size_y,
     Returns:
         tuple: Updated positions, velocities, charges, masses, and charge-to-mass ratios for all particles.
     """
-    max_vx = jnp.max(jnp.abs(vs_n[:, 0]))
+    # Compute max_vx using only active particles (non-zero mass and charge)
+    active_mask = (ms > 0) & (qs != 0)
+    active_vx = jnp.where(active_mask, vs_n[:, 0], 0.0)
+    max_vx = jnp.max(jnp.abs(active_vx))
     xs_n, vs_n, qs, q_ms, ms = vmap(
         lambda x_n, v_n, q, q_m, m: set_BC_single_particle(x_n, v_n, q, q_m, m, dx, grid, box_size_x, box_size_y, box_size_z, BC_left, BC_right, mixed_BC_weight, COR_left, COR_right, max_vx)
     )(xs_n, vs_n, qs, q_ms, ms)

--- a/jaxincell/_boundary_conditions.py
+++ b/jaxincell/_boundary_conditions.py
@@ -4,7 +4,7 @@ from ._constants import speed_of_light
 
 __all__ = ['set_BC_single_particle', 'set_BC_particles', 'set_BC_single_particle_positions', 'set_BC_positions']
 
-def set_BC_single_particle(x_n, v_n, q, q_m, m, dx, grid, box_size_x, box_size_y, box_size_z, BC_left, BC_right, mixed_BC_weight):
+def set_BC_single_particle(x_n, v_n, q, q_m, m, dx, grid, box_size_x, box_size_y, box_size_z, BC_left, BC_right, mixed_BC_weight, COR_left, COR_right, max_vx=1.0):
     """
     Applies boundary conditions (BCs) to a single particle's position and velocity.
 
@@ -21,7 +21,14 @@ def set_BC_single_particle(x_n, v_n, q, q_m, m, dx, grid, box_size_x, box_size_y
             0: Periodic
             1: Reflective
             2: Absorbing
-            3: Mixed (half absorbed, half reflected — halves q and m, reflects position and velocity)
+            3: Mixed (mixed_BC_weight fraction reflected — scales q and m, reflects position and velocity)
+            4: Velocity-dependent mixed (weight = clamp(1 - |vx| / max_vx, 0, 1); slow particles reflect
+               more, fast particles absorbed more; q_m unchanged)
+        mixed_BC_weight (float): Fraction of macroparticle reflected for BC=3; between 0 and 1.
+        max_vx (float): Maximum |vx| across all particles, used to normalize BC=4 weights.
+        COR_left (float): Coefficient of restitution at the left wall; between 0 and 1.
+            1 = perfectly elastic (no energy loss), 0 = fully inelastic (particle stops).
+        COR_right (float): Coefficient of restitution at the right wall; between 0 and 1.
 
     Returns:
         tuple: Updated position (x_n), velocity (v_n), charge (q), charge-to-mass ratio (q_m), and mass (m).
@@ -37,44 +44,48 @@ def set_BC_single_particle(x_n, v_n, q, q_m, m, dx, grid, box_size_x, box_size_y
     x_n0 = jnp.select(
         [hit_left_boundary, hit_right_boundary],
         [jnp.select(
-            # Periodic, Reflective, Absorbing, Mixed
-            [BC_left == 0, BC_left == 1, BC_left == 2, BC_left == 3],
-            [(x_n[0] + box_size_x / 2) % box_size_x - box_size_x / 2, -box_size_x - x_n[0], grid[0] - 1.5 * dx, -box_size_x - x_n[0]]
+            # Periodic, Reflective, Absorbing, Mixed, Vel-dep Mixed
+            [BC_left == 0, BC_left == 1, BC_left == 2, BC_left == 3, BC_left == 4],
+            [(x_n[0] + box_size_x / 2) % box_size_x - box_size_x / 2, -box_size_x - x_n[0], grid[0] - 1.5 * dx, -box_size_x - x_n[0], -box_size_x - x_n[0]]
         ), jnp.select(
-            # Periodic, Reflective, Absorbing, Mixed
-            [BC_right == 0, BC_right == 1, BC_right == 2, BC_right == 3],
-            [(x_n[0] + box_size_x / 2) % box_size_x - box_size_x / 2, box_size_x - x_n[0], grid[-1] + 3 * dx, box_size_x - x_n[0]]
+            # Periodic, Reflective, Absorbing, Mixed, Vel-dep Mixed
+            [BC_right == 0, BC_right == 1, BC_right == 2, BC_right == 3, BC_right == 4],
+            [(x_n[0] + box_size_x / 2) % box_size_x - box_size_x / 2, box_size_x - x_n[0], grid[-1] + 3 * dx, box_size_x - x_n[0], box_size_x - x_n[0]]
         )],
         default=x_n[0]
     )
+
+    # Compute vel_dep_weight from incoming velocity before the flip
+    vel_dep_weight = jnp.clip(1.0 - jnp.abs(v_n[0]) / max_vx, 0.0, 1.0)
 
     # Update velocities for reflective or absorbing boundaries
     v_n = jnp.select(
         [hit_left_boundary, hit_right_boundary],
         [jnp.select(
-            # Periodic, Reflective, Absorbing, Mixed
-            [BC_left == 0, BC_left == 1, BC_left == 2, BC_left == 3],
-            [v_n, v_n * jnp.array([-1, 1, 1]), jnp.array([0, 0, 0]), v_n * jnp.array([-1, 1, 1])]
+            # Periodic, Reflective, Absorbing, Mixed, Vel-dep Mixed
+            [BC_left == 0, BC_left == 1, BC_left == 2, BC_left == 3, BC_left == 4],
+            [v_n, v_n * jnp.array([-COR_left, 1, 1]), jnp.array([0, 0, 0]), v_n * jnp.array([-COR_left, 1, 1]), v_n * jnp.array([-COR_left, 1, 1])]
         ), jnp.select(
-            # Periodic, Reflective, Absorbing, Mixed
-            [BC_right == 0, BC_right == 1, BC_right == 2, BC_right == 3],
-            [v_n, v_n * jnp.array([-1, 1, 1]), jnp.array([0, 0, 0]), v_n * jnp.array([-1, 1, 1])]
+            # Periodic, Reflective, Absorbing, Mixed, Vel-dep Mixed
+            [BC_right == 0, BC_right == 1, BC_right == 2, BC_right == 3, BC_right == 4],
+            [v_n, v_n * jnp.array([-COR_right, 1, 1]), jnp.array([0, 0, 0]), v_n * jnp.array([-COR_right, 1, 1]), v_n * jnp.array([-COR_right, 1, 1])]
         )],
         default=v_n
     )
 
     # Nullify charges and charge-to-mass ratio for absorbing BCs and adjust mass and charge for mixed BCs
-    absorbed = (hit_left_boundary & (BC_left == 2)) | (hit_right_boundary & (BC_right == 2))
-    mixed = (hit_left_boundary & (BC_left == 3)) | (hit_right_boundary & (BC_right == 3))
+    absorbed     = (hit_left_boundary & (BC_left == 2)) | (hit_right_boundary & (BC_right == 2))
+    mixed        = (hit_left_boundary & (BC_left == 3)) | (hit_right_boundary & (BC_right == 3))
+    vel_dep_mixed = (hit_left_boundary & (BC_left == 4)) | (hit_right_boundary & (BC_right == 4))
 
-    q   = jnp.where(absorbed, 0, jnp.where(mixed, q * mixed_BC_weight, q))
+    q   = jnp.where(absorbed, 0, jnp.where(mixed, q * mixed_BC_weight, jnp.where(vel_dep_mixed, q * vel_dep_weight, q)))
     q_m = jnp.where(absorbed, 0, q_m)
-    m   = jnp.where(mixed, m * mixed_BC_weight, m)
+    m   = jnp.where(mixed, m * mixed_BC_weight, jnp.where(vel_dep_mixed, m * vel_dep_weight, m))
 
     return jnp.array([x_n0, x_n1, x_n2]), v_n, q, q_m, m
 
 @jit
-def set_BC_particles(xs_n, vs_n, qs, ms, q_ms, dx, grid, box_size_x, box_size_y, box_size_z, BC_left, BC_right, mixed_BC_weight):
+def set_BC_particles(xs_n, vs_n, qs, ms, q_ms, dx, grid, box_size_x, box_size_y, box_size_z, BC_left, BC_right, mixed_BC_weight, COR_left, COR_right):
     """
     Applies boundary conditions to all particles in parallel.
 
@@ -89,8 +100,9 @@ def set_BC_particles(xs_n, vs_n, qs, ms, q_ms, dx, grid, box_size_x, box_size_y,
     Returns:
         tuple: Updated positions, velocities, charges, masses, and charge-to-mass ratios for all particles.
     """
+    max_vx = jnp.max(jnp.abs(vs_n[:, 0]))
     xs_n, vs_n, qs, q_ms, ms = vmap(
-        lambda x_n, v_n, q, q_m, m: set_BC_single_particle(x_n, v_n, q, q_m, m, dx, grid, box_size_x, box_size_y, box_size_z, BC_left, BC_right, mixed_BC_weight)
+        lambda x_n, v_n, q, q_m, m: set_BC_single_particle(x_n, v_n, q, q_m, m, dx, grid, box_size_x, box_size_y, box_size_z, BC_left, BC_right, mixed_BC_weight, COR_left, COR_right, max_vx)
     )(xs_n, vs_n, qs, q_ms, ms)
     return xs_n, vs_n, qs, ms, q_ms
 
@@ -114,11 +126,11 @@ def set_BC_single_particle_positions(x_n, dx, grid, box_size_x, box_size_y, box_
     x_n0 = jnp.select(
         [hit_left_boundary, hit_right_boundary],
         [jnp.select(
-            [BC_left == 0, BC_left == 1, BC_left == 2, BC_left == 3],
-            [(x_n[0] + box_size_x / 2) % box_size_x - box_size_x / 2, -box_size_x - x_n[0], grid[0] - 1.5 * dx, -box_size_x - x_n[0]]
+            [BC_left == 0, BC_left == 1, BC_left == 2, BC_left == 3, BC_left == 4],
+            [(x_n[0] + box_size_x / 2) % box_size_x - box_size_x / 2, -box_size_x - x_n[0], grid[0] - 1.5 * dx, -box_size_x - x_n[0], -box_size_x - x_n[0]]
         ), jnp.select(
-            [BC_right == 0, BC_right == 1, BC_right == 2, BC_right == 3],
-            [(x_n[0] + box_size_x / 2) % box_size_x - box_size_x / 2, box_size_x - x_n[0], grid[-1] + 3 * dx, box_size_x - x_n[0]]
+            [BC_right == 0, BC_right == 1, BC_right == 2, BC_right == 3, BC_right == 4],
+            [(x_n[0] + box_size_x / 2) % box_size_x - box_size_x / 2, box_size_x - x_n[0], grid[-1] + 3 * dx, box_size_x - x_n[0], box_size_x - x_n[0]]
         )],
         x_n[0]
     )

--- a/jaxincell/_diagnostics.py
+++ b/jaxincell/_diagnostics.py
@@ -123,7 +123,6 @@ def diagnostics(output):
         total_ke_electrons = 0.5 * jnp.sum(mass_electrons_t * v_sq_electrons_per_particle, axis=-1)
         total_ke_ions      = 0.5 * jnp.sum(mass_ions_t      * v_sq_ions_per_particle,      axis=-1)
     else:
-        # Fallback: fixed initial masses — correct for BC=0/1/2, wrong for BC=3
         total_ke_electrons = 0.5 * jnp.sum(mass_electrons_array * v_sq_electrons_per_particle, axis=-1)
         total_ke_ions      = 0.5 * jnp.sum(mass_ions_array      * v_sq_ions_per_particle,      axis=-1)
 

--- a/jaxincell/_simulation.py
+++ b/jaxincell/_simulation.py
@@ -119,12 +119,12 @@ def initialize_simulation_parameters(user_parameters={}):
         "relativistic": False,                    # Use relativistic Boris pusher
         "tolerance_Picard_iterations_implicit_CN": 1e-6, # Tolerance for Picard iterations in implicit Crank-Nicholson method
         "mixed_BC_weight": 1.0,                      # Fraction of macroparticle reflected at mixed BC wall (BC=3); must be between 0 and 1
-        "COR_left":  0.5,                            # Coefficient of restitution at left wall (1=elastic, 0=fully inelastic); applies to BC=1,3,4
-        "COR_right": 0.5,                            # Coefficient of restitution at right wall
+        "COR_left":  1.0,                            # Coefficient of restitution at left wall (1=elastic, 0=fully inelastic); applies to BC=1,3,4
+        "COR_right": 1.0,                            # Coefficient of restitution at right wall
 
         # Boundary conditions
-        "particle_BC_left":  4,                   # Left boundary condition for particles
-        "particle_BC_right": 4,                   # Right boundary condition for particles
+        "particle_BC_left":  0,                   # Left boundary condition for particles
+        "particle_BC_right": 0,                   # Right boundary condition for particles
         "field_BC_left":     0,                   # Left boundary condition for fields
         "field_BC_right":    0,                   # Right boundary condition for fields
 

--- a/jaxincell/_simulation.py
+++ b/jaxincell/_simulation.py
@@ -118,15 +118,15 @@ def initialize_simulation_parameters(user_parameters={}):
         "ion_mass_over_proton_mass": 1,           # Ion mass in units of the proton mass
         "relativistic": False,                    # Use relativistic Boris pusher
         "tolerance_Picard_iterations_implicit_CN": 1e-6, # Tolerance for Picard iterations in implicit Crank-Nicholson method
-        "mixed_BC_weight": 1.0,                      # Fraction of macroparticle reflected at mixed BC wall (BC=3); must be between 0 and 1
-        "COR_left":  1.0,                            # Coefficient of restitution at left wall (1=elastic, 0=fully inelastic); applies to BC=1,3,4
-        "COR_right": 1.0,                            # Coefficient of restitution at right wall
 
         # Boundary conditions
         "particle_BC_left":  0,                   # Left boundary condition for particles
         "particle_BC_right": 0,                   # Right boundary condition for particles
         "field_BC_left":     0,                   # Left boundary condition for fields
         "field_BC_right":    0,                   # Right boundary condition for fields
+        "mixed_BC_weight":   1.0,                 # Fraction of macroparticle reflected at mixed BC wall (BC=3); must be between 0 and 1
+        "COR_left":          1.0,                 # Coefficient of restitution at left wall (1=elastic, 0=fully inelastic)
+        "COR_right":         1.0,                 # Coefficient of restitution at right wall
 
         # External fields (initialized to zero)
         "external_electric_field_amplitude":  0,   # Amplitude of sinusoidal (cos) perturbation in x
@@ -568,18 +568,6 @@ def simulation(input_parameters={}, number_grid_points=100, number_pseudoelectro
     COR_left  = parameters["COR_left"]
     COR_right = parameters["COR_right"]
 
-    assert 0.0 <= COR_left  <= 1.0, f"COR_left must be between 0 and 1, got {COR_left}"
-    assert 0.0 <= COR_right <= 1.0, f"COR_right must be between 0 and 1, got {COR_right}"
-
-    # Coerce degenerate mixed_BC_weight values: weight=0 → fully absorbing (BC=2), weight=1 → fully reflective (BC=1)
-    assert 0.0 <= mixed_BC_weight <= 1.0, f"mixed_BC_weight must be between 0 and 1, got {mixed_BC_weight}"
-    if mixed_BC_weight == 0.0:
-        particle_BC_left  = 2 if particle_BC_left  == 3 else particle_BC_left
-        particle_BC_right = 2 if particle_BC_right == 3 else particle_BC_right
-    elif mixed_BC_weight == 1.0:
-        particle_BC_left  = 1 if particle_BC_left  == 3 else particle_BC_left
-        particle_BC_right = 1 if particle_BC_right == 3 else particle_BC_right
-
     # **Use provided positions/velocities if given, otherwise use defaults**
     if positions is None:
         positions = parameters["initial_positions"]
@@ -596,7 +584,7 @@ def simulation(input_parameters={}, number_grid_points=100, number_pseudoelectro
     positions_plus1_2, velocities, qs, ms, q_ms = set_BC_particles(
         positions + (dt / 2) * velocities, velocities,
         parameters["charges"], parameters["masses"], parameters["charge_to_mass_ratios"],
-        dx, grid, *box_size, particle_BC_left, particle_BC_right, mixed_BC_weight, COR_left, COR_right)
+        dx, grid, *box_size, particle_BC_left, particle_BC_right)
 
     positions_minus1_2 = set_BC_positions(
         positions - (dt / 2) * velocities,
@@ -619,8 +607,9 @@ def simulation(input_parameters={}, number_grid_points=100, number_pseudoelectro
         )
         step_func = lambda carry, step_index: CN_step(
             carry, step_index, parameters, dx, dt, grid, box_size,
-            particle_BC_left, particle_BC_right, field_BC_left, field_BC_right, mixed_BC_weight,
-            parameters["number_of_particle_substeps_implicit_CN"], COR_left, COR_right
+            particle_BC_left, particle_BC_right, field_BC_left, field_BC_right,
+            mixed_BC_weight, parameters["number_of_particle_substeps_implicit_CN"],
+            COR_left, COR_right
         )
 
     @scan_tqdm(total_steps)

--- a/jaxincell/_simulation.py
+++ b/jaxincell/_simulation.py
@@ -118,11 +118,13 @@ def initialize_simulation_parameters(user_parameters={}):
         "ion_mass_over_proton_mass": 1,           # Ion mass in units of the proton mass
         "relativistic": False,                    # Use relativistic Boris pusher
         "tolerance_Picard_iterations_implicit_CN": 1e-6, # Tolerance for Picard iterations in implicit Crank-Nicholson method
-        "mixed_BC_weight": 0.5,                      # Fraction of macroparticle reflected at mixed BC wall (BC=3); must be between 0 and 1
+        "mixed_BC_weight": 1.0,                      # Fraction of macroparticle reflected at mixed BC wall (BC=3); must be between 0 and 1
+        "COR_left":  0.5,                            # Coefficient of restitution at left wall (1=elastic, 0=fully inelastic); applies to BC=1,3,4
+        "COR_right": 0.5,                            # Coefficient of restitution at right wall
 
         # Boundary conditions
-        "particle_BC_left":  0,                   # Left boundary condition for particles
-        "particle_BC_right": 0,                   # Right boundary condition for particles
+        "particle_BC_left":  4,                   # Left boundary condition for particles
+        "particle_BC_right": 4,                   # Right boundary condition for particles
         "field_BC_left":     0,                   # Left boundary condition for fields
         "field_BC_right":    0,                   # Right boundary condition for fields
 
@@ -563,6 +565,11 @@ def simulation(input_parameters={}, number_grid_points=100, number_pseudoelectro
     particle_BC_left = parameters["particle_BC_left"]
     particle_BC_right = parameters["particle_BC_right"]
     mixed_BC_weight = parameters["mixed_BC_weight"]
+    COR_left  = parameters["COR_left"]
+    COR_right = parameters["COR_right"]
+
+    assert 0.0 <= COR_left  <= 1.0, f"COR_left must be between 0 and 1, got {COR_left}"
+    assert 0.0 <= COR_right <= 1.0, f"COR_right must be between 0 and 1, got {COR_right}"
 
     # Coerce degenerate mixed_BC_weight values: weight=0 → fully absorbing (BC=2), weight=1 → fully reflective (BC=1)
     assert 0.0 <= mixed_BC_weight <= 1.0, f"mixed_BC_weight must be between 0 and 1, got {mixed_BC_weight}"
@@ -589,7 +596,7 @@ def simulation(input_parameters={}, number_grid_points=100, number_pseudoelectro
     positions_plus1_2, velocities, qs, ms, q_ms = set_BC_particles(
         positions + (dt / 2) * velocities, velocities,
         parameters["charges"], parameters["masses"], parameters["charge_to_mass_ratios"],
-        dx, grid, *box_size, particle_BC_left, particle_BC_right, mixed_BC_weight)
+        dx, grid, *box_size, particle_BC_left, particle_BC_right, mixed_BC_weight, COR_left, COR_right)
 
     positions_minus1_2 = set_BC_positions(
         positions - (dt / 2) * velocities,
@@ -603,7 +610,7 @@ def simulation(input_parameters={}, number_grid_points=100, number_pseudoelectro
         )
         step_func = lambda carry, step_index: Boris_step(
             carry, step_index, parameters, dx, dt, grid, box_size,
-            particle_BC_left, particle_BC_right, field_BC_left, field_BC_right, mixed_BC_weight, field_solver
+            particle_BC_left, particle_BC_right, field_BC_left, field_BC_right, mixed_BC_weight, field_solver, COR_left, COR_right
         )
     else:
         initial_carry = (
@@ -613,7 +620,7 @@ def simulation(input_parameters={}, number_grid_points=100, number_pseudoelectro
         step_func = lambda carry, step_index: CN_step(
             carry, step_index, parameters, dx, dt, grid, box_size,
             particle_BC_left, particle_BC_right, field_BC_left, field_BC_right, mixed_BC_weight,
-            parameters["number_of_particle_substeps_implicit_CN"]
+            parameters["number_of_particle_substeps_implicit_CN"], COR_left, COR_right
         )
 
     @scan_tqdm(total_steps)

--- a/tests/test_algorithms.py
+++ b/tests/test_algorithms.py
@@ -111,6 +111,9 @@ def test_boris_step_relativistic_and_field_solver_branch():
         particle_BC_right=particle_BC_right,
         field_BC_left=field_BC_left,
         field_BC_right=field_BC_right,
+        mixed_BC_weight=1.0,
+        COR_left=1.0,
+        COR_right=1.0,
         field_solver=1,  # triggers E_from_* branch
     )
 
@@ -140,10 +143,11 @@ def test_boris_step_relativistic_and_field_solver_branch():
     assert ms_new.shape == (n_particles, 1)
     assert q_ms_new.shape == (n_particles, 1)
 
-    # step_data = (positions, velocities, E_field, B_field, J, charge_density)
-    pos_step, vel_step, E_step, B_step, J_step, rho_step = step_data
+    # step_data = (positions, velocities, masses, E_field, B_field, J, charge_density)
+    pos_step, vel_step, ms_step, E_step, B_step, J_step, rho_step = step_data
     assert pos_step.shape == (n_particles, 3)
     assert vel_step.shape == (n_particles, 3)
+    assert ms_step.shape == (n_particles, 1)
     assert E_step.shape == (G, 3)
     assert B_step.shape == (G, 3)
     assert J_step.shape == (G, 3)
@@ -194,6 +198,9 @@ def test_cn_step_shapes_and_substepping():
         particle_BC_right=particle_BC_right,
         field_BC_left=field_BC_left,
         field_BC_right=field_BC_right,
+        mixed_BC_weight=1.0,
+        COR_left=1.0,
+        COR_right=1.0,
         num_substeps=num_substeps,
     )
 
@@ -209,10 +216,11 @@ def test_cn_step_shapes_and_substepping():
     assert ms_new.shape == (n_particles, 1)
     assert q_ms_new.shape == (n_particles, 1)
 
-    # step_data = (positions_plus1, velocities_plus1, E_field, B_field, J, charge_density)
-    pos_step, vel_step, E_step, B_step, J_step, rho_step = step_data
+    # step_data = (positions_plus1, velocities_plus1, masses_new, E_field, B_field, J, charge_density)
+    pos_step, vel_step, ms_step, E_step, B_step, J_step, rho_step = step_data
     assert pos_step.shape == (n_particles, 3)
     assert vel_step.shape == (n_particles, 3)
+    assert ms_step.shape == (n_particles, 1)
     assert E_step.shape == (G, 3)
     assert B_step.shape == (G, 3)
     assert J_step.shape == (G, 3)

--- a/tests/test_boundary_conditions.py
+++ b/tests/test_boundary_conditions.py
@@ -11,6 +11,7 @@ def test_set_BC_single_particle_periodic():
     v_n = jnp.array([1.0, 1.0, 1.0])
     q = 1.0
     q_m = 1.0
+    m = 1.0
     dx = 0.1
     grid = jnp.linspace(0.0, 1, 10)
     box_size_x = 2.0
@@ -19,8 +20,8 @@ def test_set_BC_single_particle_periodic():
     BC_left = 0
     BC_right = 0
 
-    x_n_updated, v_n_updated, q_updated, q_m_updated = set_BC_single_particle(
-        x_n, v_n, q, q_m, dx, grid, box_size_x, box_size_y, box_size_z, BC_left, BC_right
+    x_n_updated, v_n_updated, q_updated, q_m_updated, _ = set_BC_single_particle(
+        x_n, v_n, q, q_m, m, dx, grid, box_size_x, box_size_y, box_size_z, BC_left, BC_right
     )
 
     assert jnp.allclose(x_n_updated, jnp.array([0.1, 0.5, 0.8])), "Periodic BC failed for position"
@@ -33,6 +34,7 @@ def test_set_BC_single_particle_reflective():
     v_n = jnp.array([1.0, 1.0, 1.0])
     q = 1.0
     q_m = 1.0
+    m = 1.0
     dx = 0.1
     grid = jnp.linspace(-1.0, 1.0, 10)
     box_size_x = 2.0
@@ -41,8 +43,8 @@ def test_set_BC_single_particle_reflective():
     BC_left = 1
     BC_right = 1
 
-    x_n_updated, v_n_updated, q_updated, q_m_updated = set_BC_single_particle(
-        x_n, v_n, q, q_m, dx, grid, box_size_x, box_size_y, box_size_z, BC_left, BC_right
+    x_n_updated, v_n_updated, q_updated, q_m_updated, _ = set_BC_single_particle(
+        x_n, v_n, q, q_m, m, dx, grid, box_size_x, box_size_y, box_size_z, BC_left, BC_right
     )
 
     assert jnp.allclose(x_n_updated, jnp.array([-0.9, -1.0, -1.0])), "Reflective BC failed for position"
@@ -55,6 +57,7 @@ def test_set_BC_single_particle_absorbing():
     v_n = jnp.array([1.0, 1.0, 1.0])
     q = 1.0
     q_m = 1.0
+    m = 1.0
     dx = 0.1
     grid = jnp.linspace(-1.0, 1.0, 10)
     box_size_x = 2.0
@@ -63,8 +66,8 @@ def test_set_BC_single_particle_absorbing():
     BC_left = 2
     BC_right = 2
 
-    x_n_updated, v_n_updated, q_updated, q_m_updated = set_BC_single_particle(
-        x_n, v_n, q, q_m, dx, grid, box_size_x, box_size_y, box_size_z, BC_left, BC_right
+    x_n_updated, v_n_updated, q_updated, q_m_updated, _ = set_BC_single_particle(
+        x_n, v_n, q, q_m, m, dx, grid, box_size_x, box_size_y, box_size_z, BC_left, BC_right
     )
 
     assert jnp.allclose(x_n_updated, jnp.array([1.3, -1.0, -1.0])), "Absorbing BC failed for position"
@@ -77,6 +80,7 @@ def test_set_BC_single_particle_mixed():
     v_n = jnp.array([1.0, 1.0, 1.0])
     q = 1.0
     q_m = 1.0
+    m = 1.0
     dx = 0.1
     grid = jnp.linspace(-1.0, 1.0, 10)
     box_size_x = 2.0
@@ -85,8 +89,8 @@ def test_set_BC_single_particle_mixed():
     BC_left = 1
     BC_right = 2
 
-    x_n_updated, v_n_updated, q_updated, q_m_updated = set_BC_single_particle(
-        x_n, v_n, q, q_m, dx, grid, box_size_x, box_size_y, box_size_z, BC_left, BC_right
+    x_n_updated, v_n_updated, q_updated, q_m_updated, _ = set_BC_single_particle(
+        x_n, v_n, q, q_m, m, dx, grid, box_size_x, box_size_y, box_size_z, BC_left, BC_right
     )
 
     assert jnp.allclose(x_n_updated, jnp.array([-0.9, -1.0, -1.0])), "Mixed BC failed for position"
@@ -179,6 +183,7 @@ def test_set_BC_single_particle_periodic():
     v_n = jnp.array([1.0, 1.0, 1.0])
     q = 1.0
     q_m = 1.0
+    m = 1.0
     dx = 0.1
     grid = jnp.linspace(-1.0, 1.0, 10)
     box_size_x = 2.0
@@ -187,8 +192,8 @@ def test_set_BC_single_particle_periodic():
     BC_left = 0
     BC_right = 0
 
-    x_n_updated, v_n_updated, q_updated, q_m_updated = set_BC_single_particle(
-        x_n, v_n, q, q_m, dx, grid, box_size_x, box_size_y, box_size_z, BC_left, BC_right
+    x_n_updated, v_n_updated, q_updated, q_m_updated, _ = set_BC_single_particle(
+        x_n, v_n, q, q_m, m, dx, grid, box_size_x, box_size_y, box_size_z, BC_left, BC_right
     )
 
     assert jnp.allclose(x_n_updated, jnp.array([1.0, -1.0, -1.0])), "Periodic BC failed for position"
@@ -201,6 +206,7 @@ def test_set_BC_single_particle_reflective():
     v_n = jnp.array([1.0, 1.0, 1.0])
     q = 1.0
     q_m = 1.0
+    m = 1.0
     dx = 0.1
     grid = jnp.linspace(-1.0, 1.0, 10)
     box_size_x = 2.0
@@ -209,8 +215,8 @@ def test_set_BC_single_particle_reflective():
     BC_left = 1
     BC_right = 1
 
-    x_n_updated, v_n_updated, q_updated, q_m_updated = set_BC_single_particle(
-        x_n, v_n, q, q_m, dx, grid, box_size_x, box_size_y, box_size_z, BC_left, BC_right
+    x_n_updated, v_n_updated, q_updated, q_m_updated, _ = set_BC_single_particle(
+        x_n, v_n, q, q_m, m, dx, grid, box_size_x, box_size_y, box_size_z, BC_left, BC_right
     )
 
     assert jnp.allclose(x_n_updated, jnp.array([-0.9, -1.0, -1.0])), "Reflective BC failed for position"
@@ -223,6 +229,7 @@ def test_set_BC_single_particle_absorbing():
     v_n = jnp.array([1.0, 1.0, 1.0])
     q = 1.0
     q_m = 1.0
+    m = 1.0
     dx = 0.1
     grid = jnp.linspace(-1.0, 1.0, 10)
     box_size_x = 2.0
@@ -231,8 +238,8 @@ def test_set_BC_single_particle_absorbing():
     BC_left = 2
     BC_right = 2
 
-    x_n_updated, v_n_updated, q_updated, q_m_updated = set_BC_single_particle(
-        x_n, v_n, q, q_m, dx, grid, box_size_x, box_size_y, box_size_z, BC_left, BC_right
+    x_n_updated, v_n_updated, q_updated, q_m_updated, _ = set_BC_single_particle(
+        x_n, v_n, q, q_m, m, dx, grid, box_size_x, box_size_y, box_size_z, BC_left, BC_right
     )
 
     assert jnp.allclose(x_n_updated, jnp.array([1.3, -1.0, -1.0])), "Absorbing BC failed for position"
@@ -245,6 +252,7 @@ def test_set_BC_single_particle_mixed():
     v_n = jnp.array([1.0, 1.0, 1.0])
     q = 1.0
     q_m = 1.0
+    m = 1.0
     dx = 0.1
     grid = jnp.linspace(-1.0, 1.0, 10)
     box_size_x = 2.0
@@ -253,14 +261,48 @@ def test_set_BC_single_particle_mixed():
     BC_left = 1
     BC_right = 2
 
-    x_n_updated, v_n_updated, q_updated, q_m_updated = set_BC_single_particle(
-        x_n, v_n, q, q_m, dx, grid, box_size_x, box_size_y, box_size_z, BC_left, BC_right
+    x_n_updated, v_n_updated, q_updated, q_m_updated, _ = set_BC_single_particle(
+        x_n, v_n, q, q_m, m, dx, grid, box_size_x, box_size_y, box_size_z, BC_left, BC_right
     )
 
     assert jnp.allclose(x_n_updated, jnp.array([-0.9, -1.0, -1.0])), "Mixed BC failed for position"
     assert jnp.allclose(v_n_updated, jnp.array([-1.0, 1.0, 1.0])), "Mixed BC failed for velocity"
     assert q_updated == 1.0, "Mixed BC failed for charge"
     assert q_m_updated == 1.0, "Mixed BC failed for charge-to-mass ratio"
+
+def test_set_BC_single_particle_bc3():
+    dx = 0.1
+    grid = jnp.linspace(-1.0, 1.0, 10)
+    box_size_x = 2.0
+    box_size_y = 2.0
+    box_size_z = 2.0
+    q = 2.0
+    q_m = 0.5
+    m = 4.0
+
+    # Particle exits left wall (BC_left = 3)
+    x_n = jnp.array([-1.1, 0.0, 0.0])
+    v_n = jnp.array([-1.0, 0.5, 0.3])
+    x_n_updated, v_n_updated, q_updated, q_m_updated, m_updated = set_BC_single_particle(
+        x_n, v_n, q, q_m, m, dx, grid, box_size_x, box_size_y, box_size_z, BC_left=3, BC_right=0
+    )
+    assert jnp.allclose(x_n_updated, jnp.array([-0.9, 0.0, 0.0])), "Mixed BC left: position not reflected"
+    assert jnp.allclose(v_n_updated, jnp.array([1.0, 0.5, 0.3])), "Mixed BC left: vx not flipped"
+    assert jnp.allclose(q_updated, 1.0), "Mixed BC left: charge not halved"
+    assert jnp.allclose(q_m_updated, 0.5), "Mixed BC left: q_m must not change"
+    assert jnp.allclose(m_updated, 2.0), "Mixed BC left: mass not halved"
+
+    # Particle exits right wall (BC_right = 3)
+    x_n = jnp.array([1.1, 0.0, 0.0])
+    v_n = jnp.array([1.0, 0.5, 0.3])
+    x_n_updated, v_n_updated, q_updated, q_m_updated, m_updated = set_BC_single_particle(
+        x_n, v_n, q, q_m, m, dx, grid, box_size_x, box_size_y, box_size_z, BC_left=0, BC_right=3
+    )
+    assert jnp.allclose(x_n_updated, jnp.array([0.9, 0.0, 0.0])), "Mixed BC right: position not reflected"
+    assert jnp.allclose(v_n_updated, jnp.array([-1.0, 0.5, 0.3])), "Mixed BC right: vx not flipped"
+    assert jnp.allclose(q_updated, 1.0), "Mixed BC right: charge not halved"
+    assert jnp.allclose(q_m_updated, 0.5), "Mixed BC right: q_m must not change"
+    assert jnp.allclose(m_updated, 2.0), "Mixed BC right: mass not halved"
 
 def test_set_BC_particles_periodic():
     xs_n = jnp.array([[1.0, 2.0, 3.0], [-1.0, -2.0, -3.0]])
@@ -342,6 +384,36 @@ def test_set_BC_particles_absorbing():
     assert jnp.allclose(ms_updated, ms)
     assert jnp.allclose(q_ms_updated, expected_q_ms)
 
+def test_set_BC_particles_bc3():
+    # Three particles: one hits right wall, one hits left wall, one stays inside.
+    xs_n = jnp.array([[6.0, 0.0, 0.0], [-6.0, 0.0, 0.0], [0.0, 0.0, 0.0]])
+    vs_n = jnp.array([[1.0, 0.5, 0.3], [-1.0, 0.5, 0.3], [0.5, 0.5, 0.5]])
+    qs   = jnp.array([2.0, 2.0, 2.0])
+    ms   = jnp.array([4.0, 4.0, 4.0])
+    q_ms = jnp.array([0.5, 0.5, 0.5])
+    dx = 0.1
+    grid = jnp.linspace(-5.0, 5.0, 100)
+    box_size_x = 10.0
+    box_size_y = 10.0
+    box_size_z = 10.0
+
+    xs_n_updated, vs_n_updated, qs_updated, ms_updated, q_ms_updated = set_BC_particles(
+        xs_n, vs_n, qs, ms, q_ms, dx, grid, box_size_x, box_size_y, box_size_z, BC_left=3, BC_right=3
+    )
+
+    expected_xs = jnp.array([[4.0, 0.0, 0.0], [-4.0, 0.0, 0.0], [0.0, 0.0, 0.0]])
+    expected_vs = jnp.array([[-1.0, 0.5, 0.3], [1.0, 0.5, 0.3], [0.5, 0.5, 0.5]])
+    expected_qs = jnp.array([1.0, 1.0, 2.0])   # wall-hitting particles halved; inside unchanged
+    expected_ms = jnp.array([2.0, 2.0, 4.0])   # same
+    expected_q_ms = jnp.array([0.5, 0.5, 0.5]) # q_m never changes
+
+    assert jnp.allclose(xs_n_updated, expected_xs), "Mixed BC particles: positions wrong"
+    assert jnp.allclose(vs_n_updated, expected_vs), "Mixed BC particles: velocities wrong"
+    assert jnp.allclose(qs_updated, expected_qs), "Mixed BC particles: charges not halved"
+    assert jnp.allclose(ms_updated, expected_ms), "Mixed BC particles: masses not halved"
+    assert jnp.allclose(q_ms_updated, expected_q_ms), "Mixed BC particles: q_m must not change"
+
+
 def test_set_BC_single_particle_positions():
     x_n = jnp.array([1.0, 1.0, 1.0])
     box_size_x = 2.0
@@ -385,6 +457,22 @@ def test_set_BC_single_particle_positions():
     x_n = jnp.array([-1.1, 1.0, 1.0])
     x_n_updated = set_BC_single_particle_positions(x_n, dx, grid, box_size_x, box_size_y, box_size_z, BC_left, BC_right)
     assert jnp.allclose(x_n_updated, jnp.array([grid[0] - 1.5 * dx, -1.0, -1.0])), "Absorbing BC failed for position"
+
+    BC_left = 3
+    BC_right = 3
+    # Particle exits left wall with BC_left=3: reflected like BC=1
+    x_n = jnp.array([-1.1, 0.0, 0.0])
+    x_n_updated = set_BC_single_particle_positions(
+        x_n, dx, grid, box_size_x, box_size_y, box_size_z, BC_left=3, BC_right=0
+    )
+    assert jnp.allclose(x_n_updated, jnp.array([-0.9, 0.0, 0.0])), "Mixed BC positions left: position not reflected"
+
+    # Particle exits right wall with BC_right=3: reflected like BC=1
+    x_n = jnp.array([1.1, 0.0, 0.0])
+    x_n_updated = set_BC_single_particle_positions(
+        x_n, dx, grid, box_size_x, box_size_y, box_size_z, BC_left=0, BC_right=3
+    )
+    assert jnp.allclose(x_n_updated, jnp.array([0.9, 0.0, 0.0])), "Mixed BC positions right: position not reflected"
 
 def test_field_ghost_cells_E():
     field_BC_left = 0

--- a/tests/test_boundary_conditions.py
+++ b/tests/test_boundary_conditions.py
@@ -113,7 +113,7 @@ def test_set_BC_particles_periodic():
     BC_right = 0
 
     xs_n_updated, vs_n_updated, qs_updated, ms_updated, q_ms_updated = set_BC_particles(
-        xs_n, vs_n, qs, ms, q_ms, dx, grid, box_size_x, box_size_y, box_size_z, BC_left, BC_right
+        xs_n, vs_n, qs, ms, q_ms, dx, grid, box_size_x, box_size_y, box_size_z, BC_left, BC_right, mixed_BC_weight=0.5, COR_left=1.0, COR_right=1.0
     )
 
     assert jnp.allclose(xs_n_updated, xs_n)
@@ -137,7 +137,7 @@ def test_set_BC_particles_reflective():
     BC_right = 1
 
     xs_n_updated, vs_n_updated, qs_updated, ms_updated, q_ms_updated = set_BC_particles(
-        xs_n, vs_n, qs, ms, q_ms, dx, grid, box_size_x, box_size_y, box_size_z, BC_left, BC_right
+        xs_n, vs_n, qs, ms, q_ms, dx, grid, box_size_x, box_size_y, box_size_z, BC_left, BC_right, mixed_BC_weight=0.5, COR_left=1.0, COR_right=1.0
     )
 
     expected_xs_n = jnp.array([[4.0, 2.0, 3.0], [-4.0, -2.0, -3.0]])
@@ -164,7 +164,7 @@ def test_set_BC_particles_absorbing():
     BC_right = 2
 
     xs_n_updated, vs_n_updated, qs_updated, ms_updated, q_ms_updated = set_BC_particles(
-        xs_n, vs_n, qs, ms, q_ms, dx, grid, box_size_x, box_size_y, box_size_z, BC_left, BC_right
+        xs_n, vs_n, qs, ms, q_ms, dx, grid, box_size_x, box_size_y, box_size_z, BC_left, BC_right, mixed_BC_weight=0.5, COR_left=1.0, COR_right=1.0
     )
 
     expected_xs_n = jnp.array([[grid[-1] + 3 * dx, 2.0, 3.0], [grid[0] - 1.5 * dx, -2.0, -3.0]])
@@ -193,7 +193,7 @@ def test_set_BC_single_particle_periodic():
     BC_right = 0
 
     x_n_updated, v_n_updated, q_updated, q_m_updated, _ = set_BC_single_particle(
-        x_n, v_n, q, q_m, m, dx, grid, box_size_x, box_size_y, box_size_z, BC_left, BC_right
+        x_n, v_n, q, q_m, m, dx, grid, box_size_x, box_size_y, box_size_z, BC_left, BC_right, mixed_BC_weight=0.5, COR_left=1.0, COR_right=1.0
     )
 
     assert jnp.allclose(x_n_updated, jnp.array([1.0, -1.0, -1.0])), "Periodic BC failed for position"
@@ -216,7 +216,7 @@ def test_set_BC_single_particle_reflective():
     BC_right = 1
 
     x_n_updated, v_n_updated, q_updated, q_m_updated, _ = set_BC_single_particle(
-        x_n, v_n, q, q_m, m, dx, grid, box_size_x, box_size_y, box_size_z, BC_left, BC_right
+        x_n, v_n, q, q_m, m, dx, grid, box_size_x, box_size_y, box_size_z, BC_left, BC_right, mixed_BC_weight=0.5, COR_left=1.0, COR_right=1.0
     )
 
     assert jnp.allclose(x_n_updated, jnp.array([-0.9, -1.0, -1.0])), "Reflective BC failed for position"
@@ -239,7 +239,7 @@ def test_set_BC_single_particle_absorbing():
     BC_right = 2
 
     x_n_updated, v_n_updated, q_updated, q_m_updated, _ = set_BC_single_particle(
-        x_n, v_n, q, q_m, m, dx, grid, box_size_x, box_size_y, box_size_z, BC_left, BC_right
+        x_n, v_n, q, q_m, m, dx, grid, box_size_x, box_size_y, box_size_z, BC_left, BC_right, mixed_BC_weight=0.5, COR_left=1.0, COR_right=1.0
     )
 
     assert jnp.allclose(x_n_updated, jnp.array([1.3, -1.0, -1.0])), "Absorbing BC failed for position"
@@ -262,7 +262,7 @@ def test_set_BC_single_particle_mixed():
     BC_right = 2
 
     x_n_updated, v_n_updated, q_updated, q_m_updated, _ = set_BC_single_particle(
-        x_n, v_n, q, q_m, m, dx, grid, box_size_x, box_size_y, box_size_z, BC_left, BC_right
+        x_n, v_n, q, q_m, m, dx, grid, box_size_x, box_size_y, box_size_z, BC_left, BC_right, mixed_BC_weight=0.5, COR_left=1.0, COR_right=1.0
     )
 
     assert jnp.allclose(x_n_updated, jnp.array([-0.9, -1.0, -1.0])), "Mixed BC failed for position"
@@ -280,29 +280,130 @@ def test_set_BC_single_particle_bc3():
     q_m = 0.5
     m = 4.0
 
-    # Particle exits left wall (BC_left = 3)
+    # --- weight=0.5: half absorbed, half reflected ---
     x_n = jnp.array([-1.1, 0.0, 0.0])
     v_n = jnp.array([-1.0, 0.5, 0.3])
     x_n_updated, v_n_updated, q_updated, q_m_updated, m_updated = set_BC_single_particle(
-        x_n, v_n, q, q_m, m, dx, grid, box_size_x, box_size_y, box_size_z, BC_left=3, BC_right=0
+        x_n, v_n, q, q_m, m, dx, grid, box_size_x, box_size_y, box_size_z, BC_left=3, BC_right=0, mixed_BC_weight=0.5, COR_left=1.0, COR_right=1.0
     )
-    assert jnp.allclose(x_n_updated, jnp.array([-0.9, 0.0, 0.0])), "Mixed BC left: position not reflected"
-    assert jnp.allclose(v_n_updated, jnp.array([1.0, 0.5, 0.3])), "Mixed BC left: vx not flipped"
-    assert jnp.allclose(q_updated, 1.0), "Mixed BC left: charge not halved"
-    assert jnp.allclose(q_m_updated, 0.5), "Mixed BC left: q_m must not change"
-    assert jnp.allclose(m_updated, 2.0), "Mixed BC left: mass not halved"
+    assert jnp.allclose(x_n_updated, jnp.array([-0.9, 0.0, 0.0])), "weight=0.5 left: position not reflected"
+    assert jnp.allclose(v_n_updated, jnp.array([1.0, 0.5, 0.3])),   "weight=0.5 left: vx not flipped"
+    assert jnp.allclose(q_updated, q * 0.5),                         "weight=0.5 left: charge wrong"
+    assert jnp.allclose(q_m_updated, q_m),                           "weight=0.5 left: q_m must not change"
+    assert jnp.allclose(m_updated, m * 0.5),                         "weight=0.5 left: mass wrong"
 
-    # Particle exits right wall (BC_right = 3)
     x_n = jnp.array([1.1, 0.0, 0.0])
     v_n = jnp.array([1.0, 0.5, 0.3])
     x_n_updated, v_n_updated, q_updated, q_m_updated, m_updated = set_BC_single_particle(
-        x_n, v_n, q, q_m, m, dx, grid, box_size_x, box_size_y, box_size_z, BC_left=0, BC_right=3
+        x_n, v_n, q, q_m, m, dx, grid, box_size_x, box_size_y, box_size_z, BC_left=0, BC_right=3, mixed_BC_weight=0.5, COR_left=1.0, COR_right=1.0
     )
-    assert jnp.allclose(x_n_updated, jnp.array([0.9, 0.0, 0.0])), "Mixed BC right: position not reflected"
-    assert jnp.allclose(v_n_updated, jnp.array([-1.0, 0.5, 0.3])), "Mixed BC right: vx not flipped"
-    assert jnp.allclose(q_updated, 1.0), "Mixed BC right: charge not halved"
-    assert jnp.allclose(q_m_updated, 0.5), "Mixed BC right: q_m must not change"
-    assert jnp.allclose(m_updated, 2.0), "Mixed BC right: mass not halved"
+    assert jnp.allclose(x_n_updated, jnp.array([0.9, 0.0, 0.0])),  "weight=0.5 right: position not reflected"
+    assert jnp.allclose(v_n_updated, jnp.array([-1.0, 0.5, 0.3])), "weight=0.5 right: vx not flipped"
+    assert jnp.allclose(q_updated, q * 0.5),                        "weight=0.5 right: charge wrong"
+    assert jnp.allclose(q_m_updated, q_m),                          "weight=0.5 right: q_m must not change"
+    assert jnp.allclose(m_updated, m * 0.5),                        "weight=0.5 right: mass wrong"
+
+    # --- weight=0.25: 75% absorbed, 25% reflected ---
+    x_n = jnp.array([-1.1, 0.0, 0.0])
+    v_n = jnp.array([-1.0, 0.5, 0.3])
+    x_n_updated, v_n_updated, q_updated, q_m_updated, m_updated = set_BC_single_particle(
+        x_n, v_n, q, q_m, m, dx, grid, box_size_x, box_size_y, box_size_z, BC_left=3, BC_right=0, mixed_BC_weight=0.25, COR_left=1.0, COR_right=1.0
+    )
+    assert jnp.allclose(x_n_updated, jnp.array([-0.9, 0.0, 0.0])), "weight=0.25 left: position not reflected"
+    assert jnp.allclose(v_n_updated, jnp.array([1.0, 0.5, 0.3])),   "weight=0.25 left: vx not flipped"
+    assert jnp.allclose(q_updated, q * 0.25),                        "weight=0.25 left: charge wrong"
+    assert jnp.allclose(q_m_updated, q_m),                           "weight=0.25 left: q_m must not change"
+    assert jnp.allclose(m_updated, m * 0.25),                        "weight=0.25 left: mass wrong"
+
+    x_n = jnp.array([1.1, 0.0, 0.0])
+    v_n = jnp.array([1.0, 0.5, 0.3])
+    x_n_updated, v_n_updated, q_updated, q_m_updated, m_updated = set_BC_single_particle(
+        x_n, v_n, q, q_m, m, dx, grid, box_size_x, box_size_y, box_size_z, BC_left=0, BC_right=3, mixed_BC_weight=0.25, COR_left=1.0, COR_right=1.0
+    )
+    assert jnp.allclose(x_n_updated, jnp.array([0.9, 0.0, 0.0])),   "weight=0.25 right: position not reflected"
+    assert jnp.allclose(v_n_updated, jnp.array([-1.0, 0.5, 0.3])),  "weight=0.25 right: vx not flipped"
+    assert jnp.allclose(q_updated, q * 0.25),                        "weight=0.25 right: charge wrong"
+    assert jnp.allclose(q_m_updated, q_m),                           "weight=0.25 right: q_m must not change"
+    assert jnp.allclose(m_updated, m * 0.25),                        "weight=0.25 right: mass wrong"
+
+    # --- weight=0.75: 25% absorbed, 75% reflected ---
+    x_n = jnp.array([-1.1, 0.0, 0.0])
+    v_n = jnp.array([-1.0, 0.5, 0.3])
+    x_n_updated, v_n_updated, q_updated, q_m_updated, m_updated = set_BC_single_particle(
+        x_n, v_n, q, q_m, m, dx, grid, box_size_x, box_size_y, box_size_z, BC_left=3, BC_right=0, mixed_BC_weight=0.75, COR_left=1.0, COR_right=1.0
+    )
+    assert jnp.allclose(x_n_updated, jnp.array([-0.9, 0.0, 0.0])), "weight=0.75 left: position not reflected"
+    assert jnp.allclose(v_n_updated, jnp.array([1.0, 0.5, 0.3])),   "weight=0.75 left: vx not flipped"
+    assert jnp.allclose(q_updated, q * 0.75),                        "weight=0.75 left: charge wrong"
+    assert jnp.allclose(q_m_updated, q_m),                           "weight=0.75 left: q_m must not change"
+    assert jnp.allclose(m_updated, m * 0.75),                        "weight=0.75 left: mass wrong"
+
+    x_n = jnp.array([1.1, 0.0, 0.0])
+    v_n = jnp.array([1.0, 0.5, 0.3])
+    x_n_updated, v_n_updated, q_updated, q_m_updated, m_updated = set_BC_single_particle(
+        x_n, v_n, q, q_m, m, dx, grid, box_size_x, box_size_y, box_size_z, BC_left=0, BC_right=3, mixed_BC_weight=0.75, COR_left=1.0, COR_right=1.0
+    )
+    assert jnp.allclose(x_n_updated, jnp.array([0.9, 0.0, 0.0])),   "weight=0.75 right: position not reflected"
+    assert jnp.allclose(v_n_updated, jnp.array([-1.0, 0.5, 0.3])),  "weight=0.75 right: vx not flipped"
+    assert jnp.allclose(q_updated, q * 0.75),                        "weight=0.75 right: charge wrong"
+    assert jnp.allclose(q_m_updated, q_m),                           "weight=0.75 right: q_m must not change"
+    assert jnp.allclose(m_updated, m * 0.75),                        "weight=0.75 right: mass wrong"
+
+
+def test_set_BC_single_particle_bc4():
+    dx = 0.1
+    grid = jnp.linspace(-1.0, 1.0, 10)
+    box_size_x = 2.0
+    box_size_y = 2.0
+    box_size_z = 2.0
+    q = 2.0
+    q_m = 0.5
+    m = 4.0
+
+    # --- Left wall: |vx|=0.6, max_vx=1.0 → weight=0.4 ---
+    x_n = jnp.array([-1.1, 0.0, 0.0])
+    v_n = jnp.array([-0.6, 0.5, 0.3])
+    x_n_updated, v_n_updated, q_updated, q_m_updated, m_updated = set_BC_single_particle(
+        x_n, v_n, q, q_m, m, dx, grid, box_size_x, box_size_y, box_size_z, BC_left=4, BC_right=0, mixed_BC_weight=0.5, COR_left=1.0, COR_right=1.0, max_vx=1.0
+    )
+    assert jnp.allclose(x_n_updated, jnp.array([-0.9, 0.0, 0.0])),  "bc4 left: position not reflected"
+    assert jnp.allclose(v_n_updated, jnp.array([0.6, 0.5, 0.3])),   "bc4 left: vx not flipped"
+    assert jnp.allclose(q_updated, q * 0.4),                         "bc4 left: charge wrong"
+    assert jnp.allclose(q_m_updated, q_m),                           "bc4 left: q_m must not change"
+    assert jnp.allclose(m_updated, m * 0.4),                         "bc4 left: mass wrong"
+
+    # --- Right wall: |vx|=0.8, max_vx=1.0 → weight=0.2 ---
+    x_n = jnp.array([1.1, 0.0, 0.0])
+    v_n = jnp.array([0.8, 0.5, 0.3])
+    x_n_updated, v_n_updated, q_updated, q_m_updated, m_updated = set_BC_single_particle(
+        x_n, v_n, q, q_m, m, dx, grid, box_size_x, box_size_y, box_size_z, BC_left=0, BC_right=4, mixed_BC_weight=0.5, COR_left=1.0, COR_right=1.0, max_vx=1.0
+    )
+    assert jnp.allclose(x_n_updated, jnp.array([0.9, 0.0, 0.0])),   "bc4 right: position not reflected"
+    assert jnp.allclose(v_n_updated, jnp.array([-0.8, 0.5, 0.3])),  "bc4 right: vx not flipped"
+    assert jnp.allclose(q_updated, q * 0.2),                         "bc4 right: charge wrong"
+    assert jnp.allclose(q_m_updated, q_m),                           "bc4 right: q_m must not change"
+    assert jnp.allclose(m_updated, m * 0.2),                         "bc4 right: mass wrong"
+
+    # --- Left wall: |vx|=1.0, max_vx=2.0 → weight=0.5 (tests normalization scaling) ---
+    x_n = jnp.array([-1.1, 0.0, 0.0])
+    v_n = jnp.array([-1.0, 0.5, 0.3])
+    x_n_updated, v_n_updated, q_updated, q_m_updated, m_updated = set_BC_single_particle(
+        x_n, v_n, q, q_m, m, dx, grid, box_size_x, box_size_y, box_size_z, BC_left=4, BC_right=0, mixed_BC_weight=0.5, COR_left=1.0, COR_right=1.0, max_vx=2.0
+    )
+    assert jnp.allclose(q_updated, q * 0.5),   "bc4 max_vx=2.0: charge wrong"
+    assert jnp.allclose(q_m_updated, q_m),      "bc4 max_vx=2.0: q_m must not change"
+    assert jnp.allclose(m_updated, m * 0.5),   "bc4 max_vx=2.0: mass wrong"
+
+    # --- Inside domain: no BC applied ---
+    x_n = jnp.array([0.0, 0.0, 0.0])
+    v_n = jnp.array([0.5, 0.5, 0.5])
+    x_n_updated, v_n_updated, q_updated, q_m_updated, m_updated = set_BC_single_particle(
+        x_n, v_n, q, q_m, m, dx, grid, box_size_x, box_size_y, box_size_z, BC_left=4, BC_right=4, mixed_BC_weight=0.5, COR_left=1.0, COR_right=1.0, max_vx=1.0
+    )
+    assert jnp.allclose(q_updated, q),    "bc4 inside: charge should not change"
+    assert jnp.allclose(q_m_updated, q_m), "bc4 inside: q_m should not change"
+    assert jnp.allclose(m_updated, m),    "bc4 inside: mass should not change"
+
 
 def test_set_BC_particles_periodic():
     xs_n = jnp.array([[1.0, 2.0, 3.0], [-1.0, -2.0, -3.0]])
@@ -319,7 +420,7 @@ def test_set_BC_particles_periodic():
     BC_right = 0
 
     xs_n_updated, vs_n_updated, qs_updated, ms_updated, q_ms_updated = set_BC_particles(
-        xs_n, vs_n, qs, ms, q_ms, dx, grid, box_size_x, box_size_y, box_size_z, BC_left, BC_right
+        xs_n, vs_n, qs, ms, q_ms, dx, grid, box_size_x, box_size_y, box_size_z, BC_left, BC_right, mixed_BC_weight=0.5, COR_left=1.0, COR_right=1.0
     )
 
     assert jnp.allclose(xs_n_updated, xs_n)
@@ -343,7 +444,7 @@ def test_set_BC_particles_reflective():
     BC_right = 1
 
     xs_n_updated, vs_n_updated, qs_updated, ms_updated, q_ms_updated = set_BC_particles(
-        xs_n, vs_n, qs, ms, q_ms, dx, grid, box_size_x, box_size_y, box_size_z, BC_left, BC_right
+        xs_n, vs_n, qs, ms, q_ms, dx, grid, box_size_x, box_size_y, box_size_z, BC_left, BC_right, mixed_BC_weight=0.5, COR_left=1.0, COR_right=1.0
     )
 
     expected_xs_n = jnp.array([[4.0, 2.0, 3.0], [-4.0, -2.0, -3.0]])
@@ -370,7 +471,7 @@ def test_set_BC_particles_absorbing():
     BC_right = 2
 
     xs_n_updated, vs_n_updated, qs_updated, ms_updated, q_ms_updated = set_BC_particles(
-        xs_n, vs_n, qs, ms, q_ms, dx, grid, box_size_x, box_size_y, box_size_z, BC_left, BC_right
+        xs_n, vs_n, qs, ms, q_ms, dx, grid, box_size_x, box_size_y, box_size_z, BC_left, BC_right, mixed_BC_weight=0.5, COR_left=1.0, COR_right=1.0
     )
 
     expected_xs_n = jnp.array([[grid[-1] + 3 * dx, 2.0, 3.0], [grid[0] - 1.5 * dx, -2.0, -3.0]])
@@ -397,21 +498,144 @@ def test_set_BC_particles_bc3():
     box_size_y = 10.0
     box_size_z = 10.0
 
+    # --- weight=0.5 ---
     xs_n_updated, vs_n_updated, qs_updated, ms_updated, q_ms_updated = set_BC_particles(
-        xs_n, vs_n, qs, ms, q_ms, dx, grid, box_size_x, box_size_y, box_size_z, BC_left=3, BC_right=3
+        xs_n, vs_n, qs, ms, q_ms, dx, grid, box_size_x, box_size_y, box_size_z, BC_left=3, BC_right=3, mixed_BC_weight=0.5, COR_left=1.0, COR_right=1.0
     )
+    assert jnp.allclose(xs_n_updated, jnp.array([[4.0, 0.0, 0.0], [-4.0, 0.0, 0.0], [0.0, 0.0, 0.0]])), "weight=0.5: positions wrong"
+    assert jnp.allclose(vs_n_updated, jnp.array([[-1.0, 0.5, 0.3], [1.0, 0.5, 0.3], [0.5, 0.5, 0.5]])), "weight=0.5: velocities wrong"
+    assert jnp.allclose(qs_updated,   jnp.array([2.0 * 0.5, 2.0 * 0.5, 2.0])),  "weight=0.5: charges wrong"
+    assert jnp.allclose(ms_updated,   jnp.array([4.0 * 0.5, 4.0 * 0.5, 4.0])),  "weight=0.5: masses wrong"
+    assert jnp.allclose(q_ms_updated, q_ms),                                      "weight=0.5: q_m must not change"
 
-    expected_xs = jnp.array([[4.0, 0.0, 0.0], [-4.0, 0.0, 0.0], [0.0, 0.0, 0.0]])
-    expected_vs = jnp.array([[-1.0, 0.5, 0.3], [1.0, 0.5, 0.3], [0.5, 0.5, 0.5]])
-    expected_qs = jnp.array([1.0, 1.0, 2.0])   # wall-hitting particles halved; inside unchanged
-    expected_ms = jnp.array([2.0, 2.0, 4.0])   # same
-    expected_q_ms = jnp.array([0.5, 0.5, 0.5]) # q_m never changes
+    # --- weight=0.25: 75% absorbed ---
+    xs_n_updated, vs_n_updated, qs_updated, ms_updated, q_ms_updated = set_BC_particles(
+        xs_n, vs_n, qs, ms, q_ms, dx, grid, box_size_x, box_size_y, box_size_z, BC_left=3, BC_right=3, mixed_BC_weight=0.25, COR_left=1.0, COR_right=1.0
+    )
+    assert jnp.allclose(qs_updated,   jnp.array([2.0 * 0.25, 2.0 * 0.25, 2.0])), "weight=0.25: charges wrong"
+    assert jnp.allclose(ms_updated,   jnp.array([4.0 * 0.25, 4.0 * 0.25, 4.0])), "weight=0.25: masses wrong"
+    assert jnp.allclose(q_ms_updated, q_ms),                                       "weight=0.25: q_m must not change"
 
-    assert jnp.allclose(xs_n_updated, expected_xs), "Mixed BC particles: positions wrong"
-    assert jnp.allclose(vs_n_updated, expected_vs), "Mixed BC particles: velocities wrong"
-    assert jnp.allclose(qs_updated, expected_qs), "Mixed BC particles: charges not halved"
-    assert jnp.allclose(ms_updated, expected_ms), "Mixed BC particles: masses not halved"
-    assert jnp.allclose(q_ms_updated, expected_q_ms), "Mixed BC particles: q_m must not change"
+    # --- weight=0.75: 25% absorbed ---
+    xs_n_updated, vs_n_updated, qs_updated, ms_updated, q_ms_updated = set_BC_particles(
+        xs_n, vs_n, qs, ms, q_ms, dx, grid, box_size_x, box_size_y, box_size_z, BC_left=3, BC_right=3, mixed_BC_weight=0.75, COR_left=1.0, COR_right=1.0
+    )
+    assert jnp.allclose(qs_updated,   jnp.array([2.0 * 0.75, 2.0 * 0.75, 2.0])), "weight=0.75: charges wrong"
+    assert jnp.allclose(ms_updated,   jnp.array([4.0 * 0.75, 4.0 * 0.75, 4.0])), "weight=0.75: masses wrong"
+    assert jnp.allclose(q_ms_updated, q_ms),                                       "weight=0.75: q_m must not change"
+
+
+def test_set_BC_particles_bc4():
+    # Three particles: one hits right wall (fastest), one hits left wall (slower), one inside.
+    # max_vx is auto-computed as max(|vx|) = 2.0 (from particle 0).
+    xs_n = jnp.array([[6.0, 0.0, 0.0], [-6.0, 0.0, 0.0], [0.0, 0.0, 0.0]])
+    vs_n = jnp.array([[2.0, 0.5, 0.3], [-1.0, 0.5, 0.3], [0.5, 0.5, 0.5]])
+    qs   = jnp.array([2.0, 2.0, 2.0])
+    ms   = jnp.array([4.0, 4.0, 4.0])
+    q_ms = jnp.array([0.5, 0.5, 0.5])
+    dx = 0.1
+    grid = jnp.linspace(-5.0, 5.0, 100)
+    box_size_x = 10.0
+    box_size_y = 10.0
+    box_size_z = 10.0
+
+    xs_n_updated, vs_n_updated, qs_updated, ms_updated, q_ms_updated = set_BC_particles(
+        xs_n, vs_n, qs, ms, q_ms, dx, grid, box_size_x, box_size_y, box_size_z, BC_left=4, BC_right=4, mixed_BC_weight=0.5, COR_left=1.0, COR_right=1.0
+    )
+    # max_vx = 2.0
+    # Particle 0 (hit right, vx=2.0): weight = clamp(1 - 2.0/2.0, 0, 1) = 0.0
+    # Particle 1 (hit left, vx=-1.0 → flipped to 1.0): weight = clamp(1 - 1.0/2.0, 0, 1) = 0.5
+    # Particle 2 (inside): no change
+    assert jnp.allclose(xs_n_updated, jnp.array([[4.0, 0.0, 0.0], [-4.0, 0.0, 0.0], [0.0, 0.0, 0.0]])), "bc4 batch: positions wrong"
+    assert jnp.allclose(vs_n_updated, jnp.array([[-2.0, 0.5, 0.3], [1.0, 0.5, 0.3], [0.5, 0.5, 0.5]])),  "bc4 batch: velocities wrong"
+    assert jnp.allclose(qs_updated,   jnp.array([2.0 * 0.0, 2.0 * 0.5, 2.0])),  "bc4 batch: charges wrong"
+    assert jnp.allclose(ms_updated,   jnp.array([4.0 * 0.0, 4.0 * 0.5, 4.0])),  "bc4 batch: masses wrong"
+    assert jnp.allclose(q_ms_updated, q_ms),                                      "bc4 batch: q_m must not change"
+
+
+def test_set_BC_single_particle_COR():
+    q = 2.0
+    q_m = 0.5
+    m = 4.0
+    dx = 0.1
+    grid = jnp.linspace(-1.0, 1.0, 10)
+    box_size_x = 2.0
+    box_size_y = 2.0
+    box_size_z = 2.0
+
+    # --- BC=1, left wall, COR_left=0.5: vx flipped and halved ---
+    x_n = jnp.array([-1.1, 0.0, 0.0])
+    v_n = jnp.array([1.0, 0.5, 0.3])
+    _, v_n_updated, q_updated, q_m_updated, m_updated = set_BC_single_particle(
+        x_n, v_n, q, q_m, m, dx, grid, box_size_x, box_size_y, box_size_z,
+        BC_left=1, BC_right=1, mixed_BC_weight=0.5, COR_left=0.5, COR_right=1.0
+    )
+    assert jnp.allclose(v_n_updated[0], -0.5 * 1.0), "COR left BC=1: vx should be -COR*vx"
+    assert jnp.allclose(v_n_updated[1:], v_n[1:]),    "COR left BC=1: vy, vz unchanged"
+    assert jnp.allclose(q_updated, q),                "COR left BC=1: charge unchanged"
+    assert jnp.allclose(q_m_updated, q_m),            "COR left BC=1: q_m unchanged"
+    assert jnp.allclose(m_updated, m),                "COR left BC=1: mass unchanged"
+
+    # --- BC=1, right wall, COR_right=0.8: vx flipped and scaled ---
+    x_n = jnp.array([1.1, 0.0, 0.0])
+    v_n = jnp.array([-1.0, 0.5, 0.3])
+    _, v_n_updated, q_updated, q_m_updated, m_updated = set_BC_single_particle(
+        x_n, v_n, q, q_m, m, dx, grid, box_size_x, box_size_y, box_size_z,
+        BC_left=1, BC_right=1, mixed_BC_weight=0.5, COR_left=1.0, COR_right=0.8
+    )
+    assert jnp.allclose(v_n_updated[0], -0.8 * (-1.0)), "COR right BC=1: vx should be -COR*vx"
+    assert jnp.allclose(v_n_updated[1:], v_n[1:]),       "COR right BC=1: vy, vz unchanged"
+
+    # --- BC=3, left wall, COR_left=0.5: vx scaled AND q/m halved independently ---
+    x_n = jnp.array([-1.1, 0.0, 0.0])
+    v_n = jnp.array([1.0, 0.5, 0.3])
+    _, v_n_updated, q_updated, q_m_updated, m_updated = set_BC_single_particle(
+        x_n, v_n, q, q_m, m, dx, grid, box_size_x, box_size_y, box_size_z,
+        BC_left=3, BC_right=0, mixed_BC_weight=0.5, COR_left=0.5, COR_right=1.0
+    )
+    assert jnp.allclose(v_n_updated[0], -0.5 * 1.0), "COR+BC3: vx should be -COR*vx"
+    assert jnp.allclose(q_updated, q * 0.5),          "COR+BC3: charge halved by mixed_BC_weight"
+    assert jnp.allclose(m_updated, m * 0.5),          "COR+BC3: mass halved by mixed_BC_weight"
+    assert jnp.allclose(q_m_updated, q_m),            "COR+BC3: q_m unchanged"
+
+    # --- Inside domain: COR has no effect ---
+    x_n = jnp.array([0.0, 0.0, 0.0])
+    v_n = jnp.array([1.0, 0.5, 0.3])
+    _, v_n_updated, q_updated, q_m_updated, m_updated = set_BC_single_particle(
+        x_n, v_n, q, q_m, m, dx, grid, box_size_x, box_size_y, box_size_z,
+        BC_left=1, BC_right=1, mixed_BC_weight=0.5, COR_left=0.5, COR_right=0.5
+    )
+    assert jnp.allclose(v_n_updated, v_n), "COR inside: velocity unchanged"
+    assert jnp.allclose(q_updated, q),     "COR inside: charge unchanged"
+
+
+def test_set_BC_particles_COR():
+    # Two particles both hitting walls with COR != 1
+    xs_n = jnp.array([[6.0, 0.0, 0.0], [-6.0, 0.0, 0.0]])
+    vs_n = jnp.array([[1.0, 0.5, 0.3], [-1.0, 0.5, 0.3]])
+    qs   = jnp.array([2.0, 2.0])
+    ms   = jnp.array([4.0, 4.0])
+    q_ms = jnp.array([0.5, 0.5])
+    dx = 0.1
+    grid = jnp.linspace(-5.0, 5.0, 100)
+    box_size_x = 10.0
+    box_size_y = 10.0
+    box_size_z = 10.0
+
+    _, vs_n_updated, qs_updated, ms_updated, q_ms_updated = set_BC_particles(
+        xs_n, vs_n, qs, ms, q_ms, dx, grid, box_size_x, box_size_y, box_size_z,
+        BC_left=1, BC_right=1, mixed_BC_weight=0.5, COR_left=0.6, COR_right=0.4
+    )
+    # Particle 0 hits right wall: vx = -COR_right * 1.0 = -0.4
+    assert jnp.allclose(vs_n_updated[0, 0], -0.4), "COR batch: right wall vx wrong"
+    assert jnp.allclose(vs_n_updated[0, 1:], vs_n[0, 1:]), "COR batch: vy,vz unchanged right"
+    # Particle 1 hits left wall: vx = -COR_left * (-1.0) = 0.6
+    assert jnp.allclose(vs_n_updated[1, 0], 0.6), "COR batch: left wall vx wrong"
+    assert jnp.allclose(vs_n_updated[1, 1:], vs_n[1, 1:]), "COR batch: vy,vz unchanged left"
+    # Charges and masses unchanged for BC=1
+    assert jnp.allclose(qs_updated, qs),   "COR batch BC=1: charges unchanged"
+    assert jnp.allclose(ms_updated, ms),   "COR batch BC=1: masses unchanged"
+    assert jnp.allclose(q_ms_updated, q_ms), "COR batch BC=1: q_m unchanged"
 
 
 def test_set_BC_single_particle_positions():
@@ -430,7 +654,7 @@ def test_set_BC_positions():
     box_size_y = 10.0
     box_size_z = 10.0
     xs_n_updated = set_BC_positions(xs_n, 1, 0.1, jnp.linspace(-5.0, 5.0, 100), box_size_x, box_size_y, box_size_z, 0, 0)
-    
+
     assert jnp.allclose(xs_n_updated, xs_n), "Periodic BC failed for positions"
 
 def test_set_BC_single_particle_positions():
@@ -473,6 +697,19 @@ def test_set_BC_single_particle_positions():
         x_n, dx, grid, box_size_x, box_size_y, box_size_z, BC_left=0, BC_right=3
     )
     assert jnp.allclose(x_n_updated, jnp.array([0.9, 0.0, 0.0])), "Mixed BC positions right: position not reflected"
+
+    # BC=4 reflects position identically to BC=1
+    x_n = jnp.array([-1.1, 0.0, 0.0])
+    x_n_updated = set_BC_single_particle_positions(
+        x_n, dx, grid, box_size_x, box_size_y, box_size_z, BC_left=4, BC_right=0
+    )
+    assert jnp.allclose(x_n_updated, jnp.array([-0.9, 0.0, 0.0])), "BC=4 positions left: position not reflected"
+
+    x_n = jnp.array([1.1, 0.0, 0.0])
+    x_n_updated = set_BC_single_particle_positions(
+        x_n, dx, grid, box_size_x, box_size_y, box_size_z, BC_left=0, BC_right=4
+    )
+    assert jnp.allclose(x_n_updated, jnp.array([0.9, 0.0, 0.0])), "BC=4 positions right: position not reflected"
 
 def test_field_ghost_cells_E():
     field_BC_left = 0

--- a/tests/test_boundary_conditions.py
+++ b/tests/test_boundary_conditions.py
@@ -548,8 +548,8 @@ def test_set_BC_particles_bc4():
     # Particle 2 (inside): no change
     assert jnp.allclose(xs_n_updated, jnp.array([[4.0, 0.0, 0.0], [-4.0, 0.0, 0.0], [0.0, 0.0, 0.0]])), "bc4 batch: positions wrong"
     assert jnp.allclose(vs_n_updated, jnp.array([[-2.0, 0.5, 0.3], [1.0, 0.5, 0.3], [0.5, 0.5, 0.5]])),  "bc4 batch: velocities wrong"
-    assert jnp.allclose(qs_updated,   jnp.array([2.0 * 0.0, 2.0 * 0.5, 2.0])),  "bc4 batch: charges wrong"
-    assert jnp.allclose(ms_updated,   jnp.array([4.0 * 0.0, 4.0 * 0.5, 4.0])),  "bc4 batch: masses wrong"
+    assert jnp.allclose(qs_updated,   jnp.array([2.0 * 0.0, 2.0 * 0.5, 2.0]), atol=1e-5),  "bc4 batch: charges wrong"
+    assert jnp.allclose(ms_updated,   jnp.array([4.0 * 0.0, 4.0 * 0.5, 4.0]), atol=1e-5),  "bc4 batch: masses wrong"
     assert jnp.allclose(q_ms_updated, q_ms),                                      "bc4 batch: q_m must not change"
 
 


### PR DESCRIPTION
I built the following features: 

BC=3 (Mixed): Added a mixed absorbing/reflecting boundary condition. A fraction mixed_BC_weight of the macroparticle is reflected (position mirrored, velocity flipped); the remainder is absorbed. This is implemented by scaling the macroparticle's charge q and mass m by mixed_BC_weight on each wall hit. mixed_BC_weight=1.0 recovers fully reflective (BC=1); mixed_BC_weight=0.0 recovers fully absorbing (BC=2).

BC=4 (Velocity-dependent mixed): Added a velocity-dependent mixed BC where the reflected fraction is clamp(1 - |vx| / max_vx, 0, 1), with max_vx = max(|vx|) computed dynamically across all particles each timestep. Slow particles reflect more; fast particles are absorbed more. Only q and m are scaled — q_m is left unchanged so the particle's charge-to-mass ratio stays correct for field calculations.

Coefficient of Restitution (COR): Added COR_left and COR_right parameters (defaulting to 1.0) controlling energy loss on wall reflection: vx_after = -COR * vx_before. Applies to all reflecting BCs (BC=1, 3, 4) since COR is a wall property. Only the normal component vx is scaled; vy and vz are unchanged. Validated to [0, 1].

Diagnostics fix: _diagnostics.py now uses time-varying masses (masses_over_time) when computing total kinetic energy, rather than fixed initial masses. This required adding ms to the per-step output tuple in _algorithms.py so masses are tracked across the simulation. This was necessary for mixed BCs where macroparticle mass decreases on each wall hit.

Refactor: Replaced nested jnp.where chains in _boundary_conditions.py with jnp.select for readability and extensibility to new BC types.

Tests: Added tests to tests/test_boundary_conditions.py covering: BC=3 single-particle and batch behavior (charge/mass scaling, position reflection, velocity flip); BC=4 velocity-dependent weight (slow vs. fast particle behavior, q_m invariance); COR scaling for single particles and batches across BC=1, 3, and 4; and edge cases (particle inside domain unchanged, COR=1 recovers elastic reflection).