### PR TITLE
Fix documentation rendering found by reading the published site

### DIFF
--- a/docs/examples/inference.md
+++ b/docs/examples/inference.md
@@ -6,13 +6,15 @@ The script defines a differentiable growth-rate estimator, checks it against a s
 and then recovers the drift speed with a damped Newton iteration in $\log_{10}v_d$
 driven by forward-mode derivatives.
 
+The core of the script is the estimator, which turns one simulation into a single
+differentiable number:
+
 ```{literalinclude} ../../examples/inference_two_stream.py
 :language: python
-:lines: 1-120
+:lines: 105-155
 ```
 
-The full script is longer; the part shown covers the growth-rate estimator. Three
-choices make the inverse problem well behaved:
+Three choices make the inverse problem well behaved:
 
 * the fit window is a fixed fraction of the time series and does not depend on the
   drift speed, so that the estimator is a smooth function of its input;

--- a/docs/examples/scaling.md
+++ b/docs/examples/scaling.md
@@ -5,9 +5,12 @@ energy error as the number of grid points, the number of particles, the number o
 steps and the time step are increased by a factor 1.5 four times. Each configuration is
 a new compilation, so the script first runs one warm-up simulation.
 
+The measurement loop times each configuration and records the largest relative
+energy error of the run:
+
 ```{literalinclude} ../../examples/scaling_energy_time.py
 :language: python
-:lines: 1-60
+:lines: 80-124
 ```
 
 The figure below is the equivalent measurement made for this documentation, timed

--- a/jaxincell/_fields.py
+++ b/jaxincell/_fields.py
@@ -7,14 +7,18 @@ __all__ = ['E_from_Gauss_1D_FFT', 'E_from_Poisson_1D_FFT', 'E_from_Gauss_1D_Cart
 
 @jit
 def E_from_Gauss_1D_FFT(charge_density, dx):
-    """
-    Solve for the electric field E = -d(phi)/dx using FFT, 
-    where phi is derived from the 1D Gauss' law equation.
-    Parameters:
-    charge_density : 1D numpy array, source term (right-hand side of Poisson equation)
-    dx : float, grid spacing in the x-direction
+    """Solve Gauss's law for the longitudinal electric field with an FFT.
+
+    Solves ``dE/dx = rho / epsilon_0`` in Fourier space, ``E(k) = -i rho(k) / (epsilon_0 k)``,
+    with the mean field set to zero. Exact for the discrete Fourier modes of a
+    periodic box.
+
+    Args:
+        charge_density (array): Charge density on the grid, shape ``(G,)``, in C/m^3.
+        dx (float): Grid spacing in metres.
+
     Returns:
-    E : 1D numpy array, electric field
+        array: Electric field on the grid, shape ``(G,)``, in V/m.
     """
     # Get the number of grid points
     nx = len(charge_density)
@@ -32,14 +36,18 @@ def E_from_Gauss_1D_FFT(charge_density, dx):
 
 @jit
 def E_from_Poisson_1D_FFT(charge_density, dx):
-    """
-    Solve for the electric field E = -d(phi)/dx using FFT, 
-    where phi is derived from the 1D Poisson equation.
-    Parameters:
-    charge_density : 1D numpy array, source term (right-hand side of Poisson equation)
-    dx : float, grid spacing in the x-direction
+    """Solve Poisson's equation for the potential with an FFT, then differentiate it.
+
+    Solves ``d2 phi/dx2 = -rho / epsilon_0`` in Fourier space and returns
+    ``E = -d phi/dx``, with the mean potential set to zero. Gives the same field as
+    :func:`E_from_Gauss_1D_FFT` and is provided as an independent route to it.
+
+    Args:
+        charge_density (array): Charge density on the grid, shape ``(G,)``, in C/m^3.
+        dx (float): Grid spacing in metres.
+
     Returns:
-    E : 1D numpy array, electric field
+        array: Electric field on the grid, shape ``(G,)``, in V/m.
     """
     # Get the number of grid points
     nx = len(charge_density)

--- a/jaxincell/_simulation.py
+++ b/jaxincell/_simulation.py
@@ -41,47 +41,53 @@ def load_parameters(input_file):
     return parameters
 
 class Simulation:
-    """
-        Calling Simulation(parameters) will create a Simulation object with the provided parameters.
-        The parameters should be provided as a dictionary, but can also be provided as a path to
-        a .toml file containing the parameters. The parameters will be cleaned and initialized using
-        the appropriate cleaner functions for each parameter section, and the simulation state will
-        be initialized based on the cleaned parameters.
+    """A particle-in-cell simulation: parameters, initial state and the time loop.
 
-        The Simulation object will expose any differentiable parameters that were provided in
-        input_parameters through Simulation_object.input_parameters. These input_parameters can then
-        be passed to the simulation() or run() bound functions to run a simulation with these
-        input_parameters exposed such that grads can be taken with respect to them. If simulation()
-        or run() is called without input_parameters, it will use the parameters provided at initialization
-        (which may include user-provided parameters and defaults) and will not overwrite any parameters
-        with the input_parameters.
+    The constructor takes a nested dictionary of parameters, or a path to a TOML
+    file containing one. Each section is validated, the defaults are filled in,
+    and the grid, the pseudo-particles and the initial fields are built. Nothing
+    is compiled until :meth:`run` is called.
 
-        Example without input parameters:
+    Parameters that are floating-point physical inputs can be changed at run time
+    without recompiling, and differentiated with respect to. They are exposed as
+    ``Simulation.input_parameters`` and accepted as the argument of :meth:`run`.
 
-        sim = Simulation(parameters)
-        simulation_output = sim.simulation()
-        or
-        simulation_output = sim.run()
+    Args:
+        parameters (dict or str or pathlib.Path, optional): The parameter tree, or
+            a path to a TOML file. Defaults to the built-in configuration, which
+            runs a two-stream instability.
 
-        
-        Example with input parameters:
+    Example:
+        Run with the parameters given at construction:
 
-        sim = Simulation(parameters)
-        input_parameters = sim.input_parameters
-        simulation_output = sim.simulation(input_parameters)
-        or
-        simulation_output = sim.run(input_parameters)
+        .. code-block:: python
 
-        
-        Additionally,
+            sim = Simulation(parameters)
+            output = sim.run()
 
-        def scalar_objective(input_parameters):
-            simulation_output = sim.run(input_parameters)
-            return some_scalar_function_of(simulation_output)
+        Re-run with a different drift speed, reusing the compiled program:
 
-        grad(scalar_objective)(input_parameters)
+        .. code-block:: python
 
-        will provide the gradient of some scalar objective function of the simulation output with respect to the input_parameters.
+            output = sim.run({"electrons": {"electrons0": {"drift_speed_x": 7e7}}})
+
+        Differentiate a scalar diagnostic with respect to that drift speed:
+
+        .. code-block:: python
+
+            import jax.numpy as jnp
+            from jax import grad
+
+            def mean_field(drift_speed):
+                out = sim.run({"electrons": {"electrons0": {"drift_speed_x": drift_speed}}})
+                return jnp.mean(out["electric_field"][:, :, 0])
+
+            derivative = grad(mean_field)(6e7)
+
+    Note:
+        Reverse-mode differentiation works with the explicit integrator only; the
+        implicit one uses a while loop, for which forward mode (``jax.jvp``,
+        ``jax.jacfwd``) must be used instead.
     """
     def __init__(self, parameters=None):
         if parameters is None:

--- a/jaxincell/_sources.py
+++ b/jaxincell/_sources.py
@@ -239,10 +239,24 @@ def current_density(xs_nminushalf, xs_n, xs_nplushalf,
 
 @partial(jit, static_argnames=('grid_size',))
 def current_density_periodic_CN(xs_n, vs_n, qs, dx, grid_start, grid_size):
-    """
-    Deposits Current J using Periodic BCs.
-    Note: We removed xs_nminushalf/plus half arguments as we use the midpoint 
-    approximation (xs_n, vs_n) consistent with CN.
+    """Deposit the current density on a periodic grid, for the implicit scheme.
+
+    Uses the midpoint approximation ``J = q v S2(x) / dx`` at the given positions
+    and velocities, rather than the charge-conserving deposit of the explicit
+    scheme, which is what the time-centred Crank-Nicolson discretisation calls for.
+    Indices are wrapped with the modulus operator, so the deposit is periodic
+    whatever the field boundary conditions are.
+
+    Args:
+        xs_n (array): Particle positions, shape ``(N, 3)``; only x is used.
+        vs_n (array): Particle velocities, shape ``(N, 3)``.
+        qs (array): Particle charges, shape ``(N, 1)``.
+        dx (float): Grid spacing in metres.
+        grid_start (float): Position of the first grid point of the target grid.
+        grid_size (int): Number of grid points; static.
+
+    Returns:
+        array: Current density on the grid, shape ``(G, 3)``, in A/m^2.
     """
     
     def compute_single_particle_J(i):


### PR DESCRIPTION
Three rendering fixes found by reading the site published from #38.

**Example excerpts.** The `literalinclude` line ranges on the inference and scaling pages cut in the middle of a function body and of a list comprehension. They now point at the growth-rate estimator (`inference_two_stream.py` lines 105-155) and the timing loop (`scaling_energy_time.py` lines 80-124), each ending on a complete statement.

**Simulation docstring.** The class docstring put its code examples in plain indented text, so the API page ran them together as prose ("sim = Simulation(parameters) simulation_output = sim.simulation() or ..."). It now has Args, Example and Note sections with python code blocks, and states that reverse-mode differentiation needs the explicit integrator.

**Kernel docstrings.** `E_from_Gauss_1D_FFT`, `E_from_Poisson_1D_FFT` and `current_density_periodic_CN` wrote their parameter and return descriptions without the blank line and indentation Napoleon needs, so those sections rendered as flat prose. Reformatted, with the argument shapes and units filled in.

Documentation and docstrings only, no behaviour change. The strict Sphinx build passes and the affected test modules are green.