### PR TITLE
Warn when a requested external field or source is silently ignored

### DIFF
--- a/docs/user_guide/external_fields.md
+++ b/docs/user_guide/external_fields.md
@@ -31,8 +31,10 @@ The scalar parameters `external_electric_field_amplitude`,
 `external_electric_field_wavenumber`, `external_magnetic_field_amplitude`,
 `external_magnetic_field_wavenumber`, `external_electric_field_function` and
 `external_magnetic_field_function` are accepted and validated, but on the `main`
-branch they do not create a field. The electric-field amplitude only appears in the
-`print_info` summary as the normalised field strength
+branch they do not create a field. Setting a non-zero amplitude or a field function
+raises a `UserWarning` at construction saying so, because the run would otherwise
+proceed silently with no external field. The electric-field amplitude only appears in
+the `print_info` summary as the normalised field strength
 $-q_e E_0 \lambda_D / k_B T_e$. Use the array form above to apply an external field.
 ```
 
@@ -72,5 +74,6 @@ sourced, how often, at what rate, where in the box and with what velocity.
 
 The section is validated (lengths of the per-source tuples must match
 `source_species`) and copied into the output, but no code path on `main` creates
-particles from it. The implementation lives on the `ds/source_particles` branch of the
-repository. Leave the section out, or keep `source_term_active = 0`.
+particles from it. Setting `source_term_active = 1` raises a `UserWarning` saying that
+no particles will be injected. The implementation lives on the `ds/source_particles`
+branch of the repository. Leave the section out, or keep `source_term_active = 0`.

--- a/jaxincell/_parameters/_external_field_parameters.py
+++ b/jaxincell/_parameters/_external_field_parameters.py
@@ -1,7 +1,10 @@
+import warnings
+
 from ._utils import build_parameter_hash, overlay_parameter_defaults
 
 __all__ = [
     "ALL_EXTERNAL_FIELD_PARAMETERS",
+    "warn_if_external_field_request_is_ignored",
     "DIFFERENTIABLE_EXTERNAL_FIELD_PARAMETERS",
     "clean_and_initialize_external_field_parameters",
     "build_external_field_hash",
@@ -34,7 +37,42 @@ def clean_and_initialize_external_field_parameters(external_field_parameters, in
     external_field_parameters["external_magnetic_field_amplitude"] = float(external_field_parameters["external_magnetic_field_amplitude"])
     external_field_parameters["external_magnetic_field_wavenumber"] = float(external_field_parameters["external_magnetic_field_wavenumber"])
 
+    warn_if_external_field_request_is_ignored(external_field_parameters)
+
     return external_field_parameters
+
+def warn_if_external_field_request_is_ignored(external_field_parameters):
+    """Warn when a requested external field would silently not be applied.
+
+    The analytic and callable forms of the external field are accepted and
+    validated, but no code path applies them: a run that asks for one through
+    these parameters gets no external field at all, with nothing in the output to
+    say so. Until they are implemented, say so at setup time and point at the
+    array form, which is applied.
+    """
+    ignored = [
+        name for name, requested in (
+            ("external_electric_field_amplitude",
+             external_field_parameters["external_electric_field_amplitude"] != 0.0),
+            ("external_magnetic_field_amplitude",
+             external_field_parameters["external_magnetic_field_amplitude"] != 0.0),
+            ("external_electric_field_function",
+             external_field_parameters["external_electric_field_function"] is not None),
+            ("external_magnetic_field_function",
+             external_field_parameters["external_magnetic_field_function"] is not None),
+        ) if requested
+    ]
+    if not ignored:
+        return
+    warnings.warn(
+        f"{', '.join(ignored)} set but not applied: this release does not build an "
+        "external field from an amplitude, a wavenumber or a function, so the "
+        "simulation will run with no external field. Supply the field on the grid "
+        "instead, for example external_field_parameters={'external_magnetic_field': "
+        "{'B': array of shape (number_grid_points, 3)}}.",
+        UserWarning,
+        stacklevel=3,
+    )
 
 def build_external_field_hash(external_field_parameters):
     return build_parameter_hash(external_field_parameters)

--- a/jaxincell/_parameters/_source_parameters.py
+++ b/jaxincell/_parameters/_source_parameters.py
@@ -1,3 +1,5 @@
+import warnings
+
 from ._utils import build_parameter_hash, overlay_parameter_defaults
 
 __all__ = [
@@ -87,6 +89,16 @@ def clean_and_initialize_source_parameters(source_parameters, input_parameters=N
 
     for key in SOURCE_INJECTION_SPEED_PARAMETERS:
         assert all(isinstance(value, float) for value in source_parameters[key]), f"All values in '{key}' must be floats. Got {source_parameters[key]}."
+
+    if source_parameters["source_term_active"]:
+        warnings.warn(
+            "source_term_active is set but particle sources are not implemented in "
+            "this release: the source parameters are validated and carried into the "
+            "output, but no particles are injected and the run is identical to one "
+            "with source_term_active = 0.",
+            UserWarning,
+            stacklevel=3,
+        )
 
     return source_parameters
 

--- a/tests/test_external_field_parameters.py
+++ b/tests/test_external_field_parameters.py
@@ -1,3 +1,5 @@
+import pytest
+
 from jaxincell._parameters._external_field_parameters import (
     clean_and_initialize_external_field_parameters,
     DEFAULT_EXTERNAL_FIELD_PARAMETERS,
@@ -58,3 +60,33 @@ def test_build_external_field_hash_is_stable_and_sensitive_to_values():
     wavenumber_modified_parameters = clean_and_initialize_external_field_parameters({"external_magnetic_field_wavenumber": 1.0})
     wavenumber_modified_hash = build_external_field_hash(wavenumber_modified_parameters)
     assert default_hash != wavenumber_modified_hash
+
+
+def test_analytic_external_field_request_warns_that_it_is_not_applied():
+    """Test jaxincell._parameters._external_field_parameters.clean_and_initialize_external_field_parameters.
+
+    Cases:
+    - a non-zero amplitude warns, because no code path builds a field from it.
+    - a field function warns for the same reason.
+    - the parameters are still preserved, so the branches that implement them keep working.
+    """
+    with pytest.warns(UserWarning, match="not applied"):
+        cleaned = clean_and_initialize_external_field_parameters(
+            {"external_magnetic_field_amplitude": 0.5})
+    assert cleaned["external_magnetic_field_amplitude"] == 0.5
+
+    with pytest.warns(UserWarning, match="external_electric_field_function"):
+        clean_and_initialize_external_field_parameters(
+            {"external_electric_field_function": lambda x, y, z, t: (0.0, 0.0, 0.0)})
+
+
+def test_external_field_defaults_do_not_warn(recwarn):
+    """Test jaxincell._parameters._external_field_parameters.clean_and_initialize_external_field_parameters.
+
+    Cases:
+    - zero amplitudes, including a wavenumber set on its own, request no field and stay silent.
+    """
+    clean_and_initialize_external_field_parameters({})
+    clean_and_initialize_external_field_parameters(
+        {"external_electric_field_amplitude": 0.0, "external_electric_field_wavenumber": 3.0})
+    assert [w for w in recwarn if issubclass(w.category, UserWarning)] == []

--- a/tests/test_source_parameters.py
+++ b/tests/test_source_parameters.py
@@ -321,3 +321,25 @@ def test_build_source_hash_is_stable_and_sensitive_to_values():
     species_changed_parameters = clean_and_initialize_source_parameters({"source_species": 0})
     species_changed_hash = build_source_hash(species_changed_parameters)
     assert default_hash != species_changed_hash
+
+
+def test_active_source_warns_that_no_particles_are_injected():
+    """Test jaxincell._parameters._source_parameters.clean_and_initialize_source_parameters.
+
+    Cases:
+    - source_term_active = 1 warns, because no code path injects particles.
+    - the parameters are still validated and preserved for the branches that use them.
+    """
+    with pytest.warns(UserWarning, match="not implemented"):
+        cleaned = clean_and_initialize_source_parameters({"source_term_active": 1})
+    assert cleaned["source_term_active"] == 1
+
+
+def test_inactive_source_does_not_warn(recwarn):
+    """Test jaxincell._parameters._source_parameters.clean_and_initialize_source_parameters.
+
+    Cases:
+    - the default, inactive source is silent.
+    """
+    clean_and_initialize_source_parameters({})
+    assert [w for w in recwarn if issubclass(w.category, UserWarning)] == []


### PR DESCRIPTION
Opening this for review rather than merging, since it changes the package rather than the documentation.

## The problem

`external_magnetic_field_amplitude`, `external_electric_field_amplitude` and the two field functions are accepted and validated, but no code path builds a field from them. A run that asks for a magnetised plasma this way is **bit-identical** to one with no external field:

| configuration | max abs B_ext | max abs v_y after 60 steps |
|---|---|---|
| no external field | 0 | 1.2801e+07 |
| `external_magnetic_field_amplitude = 0.5` | 0 | 1.2801e+07 |
| `external_electric_field_amplitude = 1e5` | 0 | 1.2801e+07 |
| `external_electric_field_function` | 0 | 1.2801e+07 |

A real 0.5 T field on 0.02c electrons rotates `v_x` into `v_y` within a few steps, so this is not a subtle difference: the request is dropped entirely and nothing in the output records it. `source_term_active = 1` behaves the same way, giving results identical to `0`.

## The change

Both cleaners now emit a `UserWarning` naming the parameter that will not be applied. The external-field warning points at the array form, which **is** applied and which I verified produces the expected gyration (`v_y` reaches 4.7e7 m/s with `B_z = 0.05` T, against exactly zero without).

A warning rather than an error, deliberately: the parameters are scaffolding for work on `ds/3D_external_fields` and `ds/source_particles`, and several existing tests assert that the cleaners preserve these values. Raising would break that machinery for no benefit. Values are still preserved; zero amplitudes and inactive sources stay silent, so `examples/input.toml` and `examples/scaling_energy_time.py` are unaffected.

## Checks

- Full suite: 256 passed. The 8 warnings are the pre-existing source tests, which set `source_term_active = 1` to exercise the tuple broadcasting.
- `flake8 --select=E9,F63,F7,F82`: 0.
- Strict Sphinx build passes; the user-guide page now records the warning.

## Not included, already covered elsewhere

- **Charge lost at the walls with `field_solver = 1`.** Depositing on the cell faces reuses the wall treatment written for cell centres, so about 0.5 % of the charge goes missing near the boundary and the two-stream growth rate comes out roughly half the kinetic value. #31 deletes `charge_density_BCs` and `single_particle_charge_density` outright, so it is yours to land there rather than something to patch here.
- **Memory of the time history.** #37 adds `snapshot_steps`, which is the right fix.
- **`time_array` is offset by one step** and its spacing is `total_steps*dt/(total_steps-1)` rather than `dt`, so entry n is labelled with a time up to one Δt early. Real but sub-timestep, and it sits in a file #31 rewrites, so I left it alone.